### PR TITLE
CSE-884 show timestamp of last export update

### DIFF
--- a/CseEightselectBasic/Components/ArticleExport.php
+++ b/CseEightselectBasic/Components/ArticleExport.php
@@ -3,6 +3,7 @@ namespace CseEightselectBasic\Components;
 
 use League\Csv\Writer;
 use CseEightselectBasic\Components\RunCronOnce;
+use CseEightselectBasic\Components\FeedLogger;
 
 class ArticleExport
 {
@@ -122,12 +123,13 @@ class ArticleExport
 
             AWSUploader::upload($filename, self::STORAGE, $feedId, $feedType);
 
+            FeedLogger::logFeed(self::CRON_NAME);   
             RunCronOnce::finishCron(self::CRON_NAME);
 
             if (getenv('ES_DEBUG')) {
                 echo('Artikel Export abgeschlossen in ' . (time() - $start) . "s\n");
             }
-            Shopware()->PluginLogger()->info('Artikel Export abgeschlossen in ' . (time() - $start) . 's');
+            Shopware()->PluginLogger()->info('Artikel Export abgeschlossen in ' . (time() - $start) . 's');        
         } catch (\Exception $exception) {
             Shopware()->PluginLogger()->error($exception);
             RunCronOnce::finishCron(self::CRON_NAME);

--- a/CseEightselectBasic/Components/ArticleExport.php
+++ b/CseEightselectBasic/Components/ArticleExport.php
@@ -129,7 +129,7 @@ class ArticleExport
             if (getenv('ES_DEBUG')) {
                 echo('Artikel Export abgeschlossen in ' . (time() - $start) . "s\n");
             }
-            Shopware()->PluginLogger()->info('Artikel Export abgeschlossen in ' . (time() - $start) . 's');        
+            Shopware()->PluginLogger()->info('Artikel Export abgeschlossen in ' . (time() - $start) . 's');
         } catch (\Exception $exception) {
             Shopware()->PluginLogger()->error($exception);
             RunCronOnce::finishCron(self::CRON_NAME);

--- a/CseEightselectBasic/Components/FeedLogger.php
+++ b/CseEightselectBasic/Components/FeedLogger.php
@@ -26,6 +26,13 @@ class FeedLogger {
     Shopware()->Db()->query($sql);
   }
 
+  public static function getLastFeedUpdate($feedName) {
+    $sql = 'SELECT last_run FROM `' . self::TABLE_NAME . '` WHERE feed_name = "' . $feedName . '"';
+    $lastRun = Shopware()->Db()->query($sql)->fetchAll();
+
+    return $lastRun;
+  }
+
   public static function createTable() 
   {
     $sqls = [

--- a/CseEightselectBasic/Components/FeedLogger.php
+++ b/CseEightselectBasic/Components/FeedLogger.php
@@ -1,0 +1,49 @@
+<?php
+namespace CseEightselectBasic\Components;
+
+class FeedLogger {
+
+  const TABLE_NAME = '8s_feeds';
+
+  /**
+  * @throws \Zend_Db_Adapter_Exception
+  * @throws \Zend_Db_Statement_Exception
+  */
+
+  public static function logFeed($feedName) {
+
+    $sql = 'INSERT INTO `' . self::TABLE_NAME . '` (feed_name, last_run)
+            VALUES ("' . $feedName . '", NOW())
+            ON DUPLICATE KEY UPDATE
+              feed_name = "'. $feedName . '",
+              last_run = NOW();';
+
+    if (getenv('ES_DEBUG')) {
+      echo  \PHP_EOL . 'SQL'  . \PHP_EOL;
+      echo $sql . \PHP_EOL;
+    }
+
+    Shopware()->Db()->query($sql);
+  }
+
+  public static function createTable() 
+  {
+    $sqls = [
+      'DROP TABLE IF EXISTS `' . self::TABLE_NAME . '`;',
+      'CREATE TABLE `' . self::TABLE_NAME . '` (
+        `feed_name` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+        `last_run` datetime DEFAULT NULL,
+        PRIMARY KEY (`feed_name`)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;'
+    ];
+
+    foreach ($sqls as $sql) {
+      Shopware()->Db()->query($sql);
+    }
+  }
+
+  public static function deleteTable() {
+    $sql = 'DROP TABLE IF EXISTS `' . self::TABLE_NAME . '`;';
+    Shopware()->Db()->query($sql);
+  }
+}

--- a/CseEightselectBasic/Components/FeedLogger.php
+++ b/CseEightselectBasic/Components/FeedLogger.php
@@ -15,7 +15,6 @@ class FeedLogger {
     $sql = 'INSERT INTO `' . self::TABLE_NAME . '` (feed_name, last_run)
             VALUES ("' . $feedName . '", NOW())
             ON DUPLICATE KEY UPDATE
-              feed_name = "'. $feedName . '",
               last_run = NOW();';
 
     if (getenv('ES_DEBUG')) {
@@ -27,26 +26,18 @@ class FeedLogger {
   }
 
   public static function getLastFeedUpdate($feedName) {
-    $sql = 'SELECT last_run FROM `' . self::TABLE_NAME . '` WHERE feed_name = "' . $feedName . '"';
-    $lastRun = Shopware()->Db()->query($sql)->fetchAll();
-
-    return $lastRun;
+    return Shopware()->Db()->fetchOne('SELECT last_run FROM ' . self::TABLE_NAME . ' WHERE feed_name = "' . $feedName . '";');
   }
 
   public static function createTable() 
   {
-    $sqls = [
-      'DROP TABLE IF EXISTS `' . self::TABLE_NAME . '`;',
-      'CREATE TABLE `' . self::TABLE_NAME . '` (
-        `feed_name` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-        `last_run` datetime DEFAULT NULL,
-        PRIMARY KEY (`feed_name`)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;'
-    ];
+    $sql = 'CREATE TABLE IF NOT EXISTS`' . self::TABLE_NAME . '` (
+              `feed_name` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+              `last_run` datetime DEFAULT NULL,
+              PRIMARY KEY (`feed_name`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;';
 
-    foreach ($sqls as $sql) {
-      Shopware()->Db()->query($sql);
-    }
+    Shopware()->Db()->query($sql);
   }
 
   public static function deleteTable() {

--- a/CseEightselectBasic/Components/QuickUpdate.php
+++ b/CseEightselectBasic/Components/QuickUpdate.php
@@ -91,9 +91,9 @@ class QuickUpdate
 
             $this->writeFile($csvWriter);
             AWSUploader::upload($filename, self::STORAGE, $feedId, $feedType);
-
+            
             $this->emptyQueue();
-            FeedLogger::logFeed(self::CRON_NAME); 
+            FeedLogger::logFeed(self::CRON_NAME);
             RunCronOnce::finishCron(self::CRON_NAME);
 
             if (getenv('ES_DEBUG')) {

--- a/CseEightselectBasic/Components/QuickUpdate.php
+++ b/CseEightselectBasic/Components/QuickUpdate.php
@@ -3,6 +3,7 @@ namespace CseEightselectBasic\Components;
 
 use League\Csv\Writer;
 use CseEightselectBasic\Components\RunCronOnce;
+use CseEightselectBasic\Components\FeedLogger;
 
 class QuickUpdate
 {
@@ -92,7 +93,7 @@ class QuickUpdate
             AWSUploader::upload($filename, self::STORAGE, $feedId, $feedType);
 
             $this->emptyQueue();
-
+            FeedLogger::logFeed(self::CRON_NAME); 
             RunCronOnce::finishCron(self::CRON_NAME);
 
             if (getenv('ES_DEBUG')) {

--- a/CseEightselectBasic/Controllers/Backend/CseEightselectBasicManualExport.php
+++ b/CseEightselectBasic/Controllers/Backend/CseEightselectBasicManualExport.php
@@ -3,6 +3,7 @@
 use CseEightselectBasic\Components\ArticleExport;
 use CseEightselectBasic\Components\QuickUpdate;
 use CseEightselectBasic\Components\RunCronOnce;
+use CseEightselectBasic\Components\FeedLogger;
 
 class Shopware_Controllers_Backend_CseEightselectBasicManualExport extends \Shopware_Controllers_Backend_ExtJs
 {
@@ -26,5 +27,15 @@ class Shopware_Controllers_Backend_CseEightselectBasicManualExport extends \Shop
     {
         $progress = RunCronOnce::getProgress(QuickUpdate::CRON_NAME);
         $this->View()->assign(['progress' => $progress]);
+    }
+
+    public function getLastFullExportDateAction() {
+        $lastRun = FeedLogger::getLastFeedUpdate(ArticleExport::CRON_NAME);
+        $this->View()->assign(['lastFullExport' => $lastRun]);
+    }
+
+    public function getLastQuickUpdateDateAction() {
+        $lastRun = FeedLogger::getLastFeedUpdate(QuickUpdate::CRON_NAME);
+        $this->View()->assign(['lastQuickUpdate' => $lastRun]);
     }
 }

--- a/CseEightselectBasic/CseEightselectBasic.php
+++ b/CseEightselectBasic/CseEightselectBasic.php
@@ -3,6 +3,7 @@ namespace CseEightselectBasic;
 
 use CseEightselectBasic\Components\ArticleExport;
 use CseEightselectBasic\Components\RunCronOnce;
+use CseEightselectBasic\Components\FeedLogger;
 use CseEightselectBasic\Models\EightselectAttribute;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Tools\SchemaTool;
@@ -379,6 +380,7 @@ class CseEightselectBasic extends Plugin
         $this->initAttributes();
         $this->initChangesQueueTable();
         RunCronOnce::createTable();
+        FeedLogger::createTable();
     }
 
     private function removeDatabase()
@@ -391,6 +393,7 @@ class CseEightselectBasic extends Plugin
         $tool->dropSchema($classes);
 
         RunCronOnce::deleteTable();
+        FeedLogger::deleteTable();
         $this->deleteChangesQueueTable;
     }
 

--- a/CseEightselectBasic/Resources/views/backend/cse_eightselect_basic_manual_export/view/detail/export.js
+++ b/CseEightselectBasic/Resources/views/backend/cse_eightselect_basic_manual_export/view/detail/export.js
@@ -9,6 +9,31 @@ Ext.define("Shopware.apps.CseEightselectBasicManualExport.view.detail.Export", {
 
     initComponent: function () {
         var me = this;
+
+        var requestLastFullExport = Ext.Ajax.request({
+            async: false,
+            url: "{url controller=CseEightselectBasicManualExport action=getLastFullExportDate}"
+        });
+        
+        var requestLastQuickUpdate = Ext.Ajax.request({
+            async: false,
+            url: "{url controller=CseEightselectBasicManualExport action=getLastQuickUpdateDate}"
+        });
+
+        var lastFullExport = Ext.decode(requestLastFullExport.responseText).lastFullExport[0];
+        var lastQuickUpdate = Ext.decode(requestLastQuickUpdate.responseText).lastQuickUpdate[0];
+
+        var lastFullExportTimeStamp = lastFullExport && lastFullExport.last_run ? lastFullExport.last_run : '';
+        var lastQuickUpdateTimeStamp = lastQuickUpdate && lastQuickUpdate.last_run ? lastQuickUpdate.last_run : '';
+
+        var lastFullExportLabel =   lastFullExportTimeStamp.length === 0 ? 
+                                    'Noch kein Voll-Export duchgeführt.' : 
+                                    'Letzter Voll-Export am: ' + lastFullExportTimeStamp;
+
+        var lastQuickUpdateLabel =  lastQuickUpdateTimeStamp.length === 0 ? 
+                                    'Noch keine Schnell-Update durchgeführt.' : 
+                                    'Letztes Schnell-Update am: ' + lastQuickUpdateTimeStamp;
+
         var FULL_BTN = {
             id: 'full-export-btn',
             textEnabled: 'Produkt Voll-Export anstoßen',
@@ -88,6 +113,30 @@ Ext.define("Shopware.apps.CseEightselectBasicManualExport.view.detail.Export", {
                         }
                     });
                     setTimeout(quickExportStatusCheck, 5000);
+                }
+            },
+            {
+                text: lastFullExportLabel,
+                id: "last-full-export-timestamp",
+                xtype: "label",
+                width: "100%",
+                margins: "30 0 0 0",
+                style: {
+                    textAlign: "center",
+                    color: "#aaa",
+                    fontSize: "11px"
+                }
+            },
+            {
+                text: lastQuickUpdateLabel,
+                id: "last-quick-update-timestamp",
+                xtype: "label",
+                width: "100%",
+                margins: "5 0 15 0",
+                style: {
+                    textAlign: "center",
+                    color: "#aaa",
+                    fontSize: "11px"
                 }
             }
         ];

--- a/CseEightselectBasic/Resources/views/backend/cse_eightselect_basic_manual_export/view/detail/export.js
+++ b/CseEightselectBasic/Resources/views/backend/cse_eightselect_basic_manual_export/view/detail/export.js
@@ -120,7 +120,7 @@ Ext.define("Shopware.apps.CseEightselectBasicManualExport.view.detail.Export", {
                 id: "last-full-export-timestamp",
                 xtype: "label",
                 width: "100%",
-                margins: "30 0 0 0",
+                margins: "30px 0px 0px 0px",
                 style: {
                     textAlign: "center",
                     color: "#aaa",
@@ -132,7 +132,7 @@ Ext.define("Shopware.apps.CseEightselectBasicManualExport.view.detail.Export", {
                 id: "last-quick-update-timestamp",
                 xtype: "label",
                 width: "100%",
-                margins: "5 0 15 0",
+                margins: "5px 0px 15px 0px",
                 style: {
                     textAlign: "center",
                     color: "#aaa",

--- a/CseEightselectBasic/Resources/views/backend/cse_eightselect_basic_manual_export/view/detail/export.js
+++ b/CseEightselectBasic/Resources/views/backend/cse_eightselect_basic_manual_export/view/detail/export.js
@@ -20,11 +20,11 @@ Ext.define("Shopware.apps.CseEightselectBasicManualExport.view.detail.Export", {
             url: "{url controller=CseEightselectBasicManualExport action=getLastQuickUpdateDate}"
         });
 
-        var lastFullExport = Ext.decode(requestLastFullExport.responseText).lastFullExport[0];
-        var lastQuickUpdate = Ext.decode(requestLastQuickUpdate.responseText).lastQuickUpdate[0];
+        var lastFullExport = Ext.decode(requestLastFullExport.responseText).lastFullExport;
+        var lastQuickUpdate = Ext.decode(requestLastQuickUpdate.responseText).lastQuickUpdate;
 
-        var lastFullExportTimeStamp = lastFullExport && lastFullExport.last_run ? lastFullExport.last_run : '';
-        var lastQuickUpdateTimeStamp = lastQuickUpdate && lastQuickUpdate.last_run ? lastQuickUpdate.last_run : '';
+        var lastFullExportTimeStamp = lastFullExport ? lastFullExport : '';
+        var lastQuickUpdateTimeStamp = lastQuickUpdate ? lastQuickUpdate : '';
 
         var lastFullExportLabel =   lastFullExportTimeStamp.length === 0 ? 
                                     'Noch kein Voll-Export duchgeführt.' : 

--- a/CseEightselectBasic/Resources/views/backend/cse_eightselect_basic_manual_export/view/detail/window.js
+++ b/CseEightselectBasic/Resources/views/backend/cse_eightselect_basic_manual_export/view/detail/window.js
@@ -2,7 +2,7 @@ Ext.define("Shopware.apps.CseEightselectBasicManualExport.view.detail.Window", {
   extend: "Enlight.app.Window",
   alias: "widget.8select-export-window",
   width: 450,
-  height: 200,
+  height: 220,
   title: "{s name=window_title}8select Manual Export{/s}",
   layout: "border",
 


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/CSE-884

**Summary**
- added new component `FeedLogger.php` / class `FeedLogger`
- create new database table `8s_feeds` to store timestamps upon installation
- show datetime of last updates for both Full Export and Quick Update in manual export modal

**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [x] Unit tests for new / changed logic exist OR no logic changes are passing

**Before any exports did run (after fresh plugin installation):**

![bildschirmfoto 2018-06-26 um 16 24 31](https://user-images.githubusercontent.com/1707307/41921786-f08109c2-7963-11e8-9be3-f8c2e6b3fc57.png)

**After Exports have been executed:**

![bildschirmfoto 2018-06-26 um 16 16 52](https://user-images.githubusercontent.com/1707307/41921802-fbac462c-7963-11e8-95a4-1f0e0afd5467.png)
