### PR TITLE
CSE-988 export variant images

### DIFF
--- a/CseEightselectBasic/Components/ArticleExport.php
+++ b/CseEightselectBasic/Components/ArticleExport.php
@@ -93,23 +93,27 @@ class ArticleExport
                 return;
             }
 
-            Shopware()->PluginLogger()->info('Führe Artikel Export aus.');
-            if (getenv('ES_DEBUG')) {
-                echo 'Führe Artikel Export aus.' . PHP_EOL;
-            }
-
             if (RunCronOnce::isRunning(self::CRON_NAME)) {
+                $message = 'Export nicht ausgeführt, es läuft bereits ein Export.';
+                Shopware()->PluginLogger()->warning($message);
                 if (getenv('ES_DEBUG')) {
-                    echo 'Export nicht ausgeführt, es läuft bereits ein Export.' . PHP_EOL;
+                    echo $message . PHP_EOL;
                 }
                 return;
             }
 
             if (!RunCronOnce::isScheduled(self::CRON_NAME)) {
+                $message = 'Export nicht ausgeführt, es ist kein Export in der Warteschleife.';
+                Shopware()->PluginLogger()->warning($message);
                 if (getenv('ES_DEBUG')) {
-                    echo 'Export nicht ausgeführt, es ist kein Export in der Warteschleife.' . PHP_EOL;
+                    echo $message . PHP_EOL;
                 }
                 return;
+            }
+
+            Shopware()->PluginLogger()->info('Führe Artikel Export aus.');
+            if (getenv('ES_DEBUG')) {
+                echo 'Führe Artikel Export aus.' . PHP_EOL;
             }
 
             RunCronOnce::runCron(self::CRON_NAME);

--- a/CseEightselectBasic/Components/ArticleExport.php
+++ b/CseEightselectBasic/Components/ArticleExport.php
@@ -199,7 +199,7 @@ class ArticleExport
     protected function getArticles($mapping, $from, $number)
     {
         $sql = 'SELECT ' . $mapping . ',
-                s_articles.id as articleID,
+                s_articles_details.articleID,
                 s_articles.laststock AS laststock,
                 s_articles_details.id as detailID,
                 s_articles_prices.price AS angebots_preis,
@@ -207,12 +207,19 @@ class ArticleExport
                 s_articles_details.active AS active,
                 s_articles_details.instock AS instock,
                 s_articles_supplier.name as marke,
+                case
+                    when s_articles_details.kind = 1 then 
+                        s_articles_details.ordernumber
+                    else 
+                        ad2.ordernumber
+                end as mastersku, 		
                 s_articles_details.ordernumber as sku,
                 s_core_tax.tax AS tax
                 FROM s_articles_details
+                INNER JOIN s_articles_details AS ad2 ON ad2.articleID = s_articles_details.articleID AND ad2.kind = 1
                 INNER JOIN s_articles ON s_articles.id = s_articles_details.articleID
                 INNER JOIN s_articles_attributes ON s_articles_attributes.articledetailsID = s_articles_details.id
-                INNER JOIN s_articles_prices ON s_articles_prices.articledetailsID = s_articles_details.id AND s_articles_prices.from = \'1\'
+                INNER JOIN s_articles_prices ON s_articles_prices.articledetailsID = s_articles_details.id AND s_articles_prices.from = 1
                 INNER JOIN s_articles_supplier ON s_articles_supplier.id = s_articles.supplierID
                 INNER JOIN s_core_tax ON s_core_tax.id = s_articles.taxID
                 LIMIT ' . $number . ' OFFSET ' . $from;

--- a/CseEightselectBasic/Components/ArticleExport.php
+++ b/CseEightselectBasic/Components/ArticleExport.php
@@ -135,7 +135,7 @@ class ArticleExport
 
             AWSUploader::upload($filename, self::STORAGE, $feedId, $feedType);
 
-            FeedLogger::logFeed(self::CRON_NAME);   
+            FeedLogger::logFeed(self::CRON_NAME);
             RunCronOnce::finishCron(self::CRON_NAME);
 
             if (getenv('ES_DEBUG')) {
@@ -207,12 +207,7 @@ class ArticleExport
                 s_articles_details.active AS active,
                 s_articles_details.instock AS instock,
                 s_articles_supplier.name as marke,
-                case
-                    when s_articles_details.kind = 1 then 
-                        s_articles_details.ordernumber
-                    else 
-                        ad2.ordernumber
-                end as mastersku, 		
+                ad2.ordernumber as mastersku,
                 s_articles_details.ordernumber as sku,
                 s_core_tax.tax AS tax
                 FROM s_articles_details

--- a/CseEightselectBasic/Components/ArticleImageMapper.php
+++ b/CseEightselectBasic/Components/ArticleImageMapper.php
@@ -31,7 +31,8 @@ class ArticleImageMapper
         LEFT JOIN s_article_img_mappings aim on aim.image_id = ai.id
         LEFT JOIN s_article_img_mapping_rules aimr on aimr.mapping_id = aim.id
         RIGHT JOIN s_article_configurator_option_relations acor ON acor.option_id = aimr.option_id AND acor.article_id = ' . $detailId . '
-        WHERE ai.articleID = ' . $articleId . ';';
+        WHERE ai.articleID = ' . $articleId . '
+        ORDER BY ai.position;';
     $variantImagesRaw = Shopware()->Db()->query($variantImagesQuery)->fetchAll();
 
     return array_map(function($image) {
@@ -49,7 +50,7 @@ class ArticleImageMapper
   * @return array
   */
   private function getParentImages($detailId, $articleId) {
-    $parentImagesQuery = 'SELECT ai.img, ai.extension FROM s_articles_img ai WHERE ai.articleID = ' . $articleId . ';';
+    $parentImagesQuery = 'SELECT ai.img, ai.extension FROM s_articles_img ai WHERE ai.articleID = ' . $articleId . ' ORDER BY ai.position;';
     $parentImagesRaw = Shopware()->Db()->query($parentImagesQuery)->fetchAll();
 
     return array_map(function($image) {

--- a/CseEightselectBasic/Components/ArticleImageMapper.php
+++ b/CseEightselectBasic/Components/ArticleImageMapper.php
@@ -1,0 +1,86 @@
+<?php
+namespace CseEightselectBasic\Components;
+
+class ArticleImageMapper
+{
+
+  public function getVariantImageMediaIdsByOrdernumber( $ordernumber ) 
+  {
+    $mediaIds = array();
+    $sql = 'SELECT articleID, id FROM s_articles_details WHERE ordernumber = ?';
+    $sArticle = Shopware()->Db()->query($sql, [$ordernumber])->fetchAll();
+    $sArticle = $sArticle[0];
+    $hasVariants = false;
+
+    $optionIDs = self::getOptionIdsByDetailId( $sArticle['id'] );
+    $allArticleImageIDs = self::getImageIdsByArticleId( $sArticle['articleID'] );
+
+    foreach( $allArticleImageIDs as $imageID ) {
+      foreach ( $optionIDs as $optionID ) {
+        if (self::doesImageMatchVariantOption($imageID, $optionID)) {
+          $matchingMediaId = Shopware()->Db()->fetchOne('SELECT media_id FROM s_articles_img WHERE id = ?', [$imageID]);
+          array_push($mediaIds, $matchingMediaId);
+
+          $hasVariants = true;
+        }
+      }
+    }
+
+    if (!$hasVariants) {
+      $imagesQuery = 'SELECT media_id FROM s_articles_img WHERE articleID = ?';
+      $standardMediaIds = Shopware()->Db()->query($imagesQuery, [$sArticle['articleID']])->fetchAll();
+
+      foreach ($standardMediaIds as $standardMedia) {
+        foreach ($standardMedia as $mediaId) {
+          array_push($mediaIds, $mediaId);
+        }
+      }
+    }
+
+    return $mediaIds;
+  }
+
+  private function getOptionIdsByDetailId( $detailID ) 
+  {
+    $sql = 'SELECT option_id FROM s_article_configurator_option_relations WHERE article_id = ' . $detailID . ';';
+    $options = Shopware()->Db()->query($sql)->fetchAll();
+    $optionIDs = array();
+
+    foreach($options as $optionData) {
+      foreach($optionData as $optionID) {
+        array_push($optionIDs, $optionID);
+      }
+    }
+
+    return $optionIDs;
+  }
+
+  private function getImageIdsByArticleId ( $articleId ) 
+  {
+    $sql = 'SELECT id FROM s_articles_img WHERE articleID = ' . $articleId . ';';
+    $images = Shopware()->Db()->query($sql)->fetchAll();
+    $imageIDs = array();
+
+    foreach ($images as $imageData) {
+      foreach($imageData as $id) {
+        array_push($imageIDs, $id);
+      }  
+    }
+    
+    return $imageIDs;
+  }
+
+  private function doesImageMatchVariantOption( $imageID, $optionID ) 
+  {
+    $mappingQuery = 'SELECT id FROM s_article_img_mappings WHERE image_id =?';
+    $targetMappingId = Shopware()->Db()->fetchOne($mappingQuery, [$imageID]);
+    $optionQuery = 'SELECT option_id FROM s_article_img_mapping_rules WHERE mapping_id = ?';
+    $targetOptionId = Shopware()->Db()->fetchOne($optionQuery, [$targetMappingId]);
+
+    if ($optionID === $targetOptionId) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+}

--- a/CseEightselectBasic/Components/ArticleImageMapper.php
+++ b/CseEightselectBasic/Components/ArticleImageMapper.php
@@ -8,13 +8,8 @@ class ArticleImageMapper
   * @throws \Exception
   * @return array
   */
-  public function getVariantImageMediaIdsByOrdernumber( $ordernumber ) 
+  public function getVariantImageMediaIdsByOrdernumber( $ordernumber, $articleVariantId, $articleId) 
   {
-    $sql = 'SELECT articleID, id FROM s_articles_details WHERE ordernumber = ?';
-    $sArticle = Shopware()->Db()->query($sql, [$ordernumber])->fetch();
-    $articleVariantId = $sArticle['id'];
-    $articleId = $sArticle['articleID'];
-
     $optionIds = self::getOptionIdsByArticleVariantId($articleVariantId);
     $articleImages = self::getImagesWithMapping($articleId);
     $variantImages = self::getVariantImages($articleImages, $optionIds);
@@ -66,12 +61,15 @@ class ArticleImageMapper
   * @return array
   */
   private function getImagesWithMapping($articleId) {
-    $mappingsSql = 'SELECT ai.id imageId, ai.media_id mediaId, GROUP_CONCAT(aimr.option_id) optionIds 
-      FROM s_articles_img ai
+    $mappingsSql = 'SELECT 
+        ai.id imageId, 
+        ai.media_id mediaId, 
+        GROUP_CONCAT(aimr.option_id) optionIds 
+        FROM s_articles_img ai
         LEFT JOIN s_article_img_mappings aim ON aim.image_id = ai.id
         LEFT JOIN s_article_img_mapping_rules aimr ON aimr.mapping_id = aim.id
-      WHERE ai.articleID = ?
-      GROUP BY ai.id;';
+        WHERE ai.articleID = ?
+        GROUP BY ai.id;';
 
     $imageMappings = Shopware()->Db()->query($mappingsSql, [$articleId])->fetchAll();
     $images = array_map(function($image) {

--- a/CseEightselectBasic/Components/ArticleImageMapper.php
+++ b/CseEightselectBasic/Components/ArticleImageMapper.php
@@ -4,83 +4,60 @@ namespace CseEightselectBasic\Components;
 class ArticleImageMapper
 {
   /**
-  * @param  int $ordernumber
+  * @param  string $ordernumber
+  * @param  int $detailId
+  * @param  int $articleId
+  * @return array
+  */
+  public function getImagesByVariant( $ordernumber, $detailId, $articleId)
+  {
+    $variantImages = self::getVariantImages($detailId, $articleId);
+    $parentImages = self::getParentImages($detailId, $articleId);
+
+    if (!empty($variantImages)) {
+      return $variantImages;
+    }
+
+    return $parentImages;
+  }
+
+  /**
+  * @param  int $detailId
+  * @param  int $articleId
   * @throws \Exception
   * @return array
   */
-  public function getVariantImageMediaIdsByOrdernumber( $ordernumber, $articleVariantId, $articleId) 
-  {
-    $optionIds = self::getOptionIdsByArticleVariantId($articleVariantId);
-    $articleImages = self::getImagesWithMapping($articleId);
-    $variantImages = self::getVariantImages($articleImages, $optionIds);
+  private function getVariantImages($detailId, $articleId) {
+    $variantImagesQuery = 'SELECT ai.img, ai.extension FROM s_articles_img ai
+        LEFT JOIN s_article_img_mappings aim on aim.image_id = ai.id
+        LEFT JOIN s_article_img_mapping_rules aimr on aimr.mapping_id = aim.id
+        RIGHT JOIN s_article_configurator_option_relations acor ON acor.option_id = aimr.option_id AND acor.article_id = ' . $detailId . '
+        WHERE ai.articleID = ' . $articleId . ';';
+    $variantImagesRaw = Shopware()->Db()->query($variantImagesQuery)->fetchAll();
 
-    $images = !empty($variantImages) ? $variantImages : $articleImages;
-
-    return self::extractMediaIds($images);
-  }
-
-  /**
-  * @param array $images
-  * @return array
-  */
-  private function extractMediaIds($images) {
-    return array_map(function($image) { return $image['mediaId']; }, $images);
-  }
-
-  /**
-  * @param array $images
-  * @param array $optionIds
-  * @return array
-  */
-  private function getVariantImages($images, $optionIds)
-  {
-    $variantImages = array_filter($images, function($image) use (&$optionIds) {
-      return !empty(array_intersect($image['optionIds'], $optionIds));
-    });
-
-    return $variantImages;
-  }
-
-  /**
-  * @param int $articleId
-  * @return array
-  */
-  private function getOptionIdsByArticleVariantId($articleId)
-  {
-    $sql = 'SELECT option_id FROM s_article_configurator_option_relations WHERE article_id = ' . $articleId . ';';
-    $options = Shopware()->Db()->query($sql)->fetchAll();
-
-    $optionIds = array_map(function($option) { return $option['option_id']; }, $options);
-
-    return $optionIds;
-  }
-
-  /**
-  * @param int $articleId
-  * @throws \Exception
-  * @return array
-  */
-  private function getImagesWithMapping($articleId) {
-    $mappingsSql = 'SELECT 
-        ai.id imageId, 
-        ai.media_id mediaId, 
-        GROUP_CONCAT(aimr.option_id) optionIds 
-        FROM s_articles_img ai
-        LEFT JOIN s_article_img_mappings aim ON aim.image_id = ai.id
-        LEFT JOIN s_article_img_mapping_rules aimr ON aimr.mapping_id = aim.id
-        WHERE ai.articleID = ?
-        GROUP BY ai.id;';
-
-    $imageMappings = Shopware()->Db()->query($mappingsSql, [$articleId])->fetchAll();
-    $images = array_map(function($image) {
+    return array_map(function($image) {
       return array(
-        imageId => $image['id'],
-        mediaId => $image['mediaId'],
-        optionIds => $image['optionIds'] == null ? [] : explode(',', $image['optionIds'])
+        img => $image['img'],
+        extension => $image['extension']
       );
-    }, $imageMappings);
+    }, $variantImagesRaw);
+  }
+  
+  /**
+  * @param  int $detailId
+  * @param  int $articleId
+  * @throws \Exception
+  * @return array
+  */
+  private function getParentImages($detailId, $articleId) {
+    $parentImagesQuery = 'SELECT ai.img, ai.extension FROM s_articles_img ai WHERE ai.articleID = ' . $articleId . ';';
+    $parentImagesRaw = Shopware()->Db()->query($parentImagesQuery)->fetchAll();
 
-    return $images;
-
+    return array_map(function($image) {
+      return array(
+        img => $image['img'],
+        extension => $image['extension']
+      );
+    }, $parentImagesRaw);
   }
 }

--- a/CseEightselectBasic/Components/ArticleImageMapper.php
+++ b/CseEightselectBasic/Components/ArticleImageMapper.php
@@ -4,20 +4,19 @@ namespace CseEightselectBasic\Components;
 class ArticleImageMapper
 {
   /**
-  * @param  string $ordernumber
   * @param  int $detailId
   * @param  int $articleId
   * @return array
   */
-  public function getImagesByVariant( $ordernumber, $detailId, $articleId)
+  public function getImagesByVariant($detailId, $articleId)
   {
     $variantImages = self::getVariantImages($detailId, $articleId);
-    $parentImages = self::getParentImages($detailId, $articleId);
 
     if (!empty($variantImages)) {
       return $variantImages;
     }
 
+    $parentImages = self::getParentImages($detailId, $articleId);
     return $parentImages;
   }
 

--- a/CseEightselectBasic/Components/FieldHelper.php
+++ b/CseEightselectBasic/Components/FieldHelper.php
@@ -52,8 +52,8 @@ class FieldHelper
                     break;
                 case 'bilder':
                     $mediaIds = ArticleImageMapper::getVariantImageMediaIdsByOrdernumber(
-                        $article['sku'], 
-                        $article['detailID'], 
+                        $article['sku'],
+                        $article['detailID'],
                         $article['articleID']
                     );
                     $value = self::getImages($mediaIds);
@@ -204,6 +204,7 @@ class FieldHelper
         foreach ($images as $image) {
             $path = 'media/image/' . $image['img'] . '.' . $image['extension'];
 
+            // mega inperformat, da dateisystem prüfung pro bild
             if ($mediaService->has($path)) {
                 $urlArray[] = $mediaService->getUrl($path);
             }

--- a/CseEightselectBasic/Components/FieldHelper.php
+++ b/CseEightselectBasic/Components/FieldHelper.php
@@ -190,15 +190,12 @@ class FieldHelper
      */
     private static function getImages($ordernumber)
     {
-
-        $mediaIds = ArticleImageMapper::getVariantImageMediaIdsByOrdernumber($ordernumber);
-
         /** @var MediaService $mediaService */
         $mediaService = Shopware()->Container()->get('shopware_media.media_service');
+        $mediaIds = ArticleImageMapper::getVariantImageMediaIdsByOrdernumber($ordernumber);
 
         foreach ($mediaIds as $mediaId) {
-            $image = Shopware()->Db()->query('SELECT img, extension FROM s_articles_img WHERE media_id = ?', [$mediaId])->fetchAll();
-            $image = $image[0];
+            $image = Shopware()->Db()->query('SELECT img, extension FROM s_articles_img WHERE media_id = ?', [$mediaId])->fetch();
 
             $path = 'media/image/' . $image['img'] . '.' . $image['extension'];
             if ($mediaService->has($path)) {

--- a/CseEightselectBasic/Components/FieldHelper.php
+++ b/CseEightselectBasic/Components/FieldHelper.php
@@ -52,7 +52,6 @@ class FieldHelper
                     break;
                 case 'bilder':
                     $images = ArticleImageMapper::getImagesByVariant(
-                        $article['sku'],
                         $article['detailID'],
                         $article['articleID']
                     );
@@ -190,7 +189,7 @@ class FieldHelper
     }
 
     /**
-     * @param  int $ordernumber
+     * @param  array $images
      * @throws \Exception
      * @return string
      */

--- a/CseEightselectBasic/Components/FieldHelper.php
+++ b/CseEightselectBasic/Components/FieldHelper.php
@@ -209,7 +209,7 @@ class FieldHelper
             }
         }
 
-        $urlString = implode(' | ', $urlArray);
+        $urlString = implode('|', $urlArray);
 
         return $urlString;
     }

--- a/CseEightselectBasic/Components/FieldHelper.php
+++ b/CseEightselectBasic/Components/FieldHelper.php
@@ -51,12 +51,13 @@ class FieldHelper
                     $value = self::getUrl($article['articleID']);
                     break;
                 case 'bilder':
-                    $mediaIds = ArticleImageMapper::getVariantImageMediaIdsByOrdernumber(
+                    $images = ArticleImageMapper::getImagesByVariant(
                         $article['sku'],
                         $article['detailID'],
                         $article['articleID']
                     );
-                    $value = self::getImages($mediaIds);
+
+                    $value = self::getImageUrls($images);
                     break;
                 case 'status':
                     $value = self::getStatus($article['active'], $article['instock'], $article['laststock']);
@@ -193,21 +194,14 @@ class FieldHelper
      * @throws \Exception
      * @return string
      */
-    private static function getImages($mediaIds)
+    private static function getImageUrls($images)
     {
         /** @var MediaService $mediaService */
         $mediaService = Shopware()->Container()->get('shopware_media.media_service');
 
-        $sql = 'SELECT img, extension FROM s_articles_img WHERE media_id IN (' . implode(",", $mediaIds) . ') ORDER BY position;';
-        $images = Shopware()->Db()->query($sql)->fetchAll();
-
         foreach ($images as $image) {
             $path = 'media/image/' . $image['img'] . '.' . $image['extension'];
-
-            // mega inperformat, da dateisystem prüfung pro bild
-            if ($mediaService->has($path)) {
-                $urlArray[] = $mediaService->getUrl($path);
-            }
+            $urlArray[] = $mediaService->getUrl($path);
         }
 
         $urlString = implode('|', $urlArray);

--- a/CseEightselectBasic/Components/FieldHelper.php
+++ b/CseEightselectBasic/Components/FieldHelper.php
@@ -198,7 +198,6 @@ class FieldHelper
         /** @var MediaService $mediaService */
         $mediaService = Shopware()->Container()->get('shopware_media.media_service');
 
-        // note: prepared statement would not interpret imploded $mediaIds as array but as single value
         $sql = 'SELECT img, extension FROM s_articles_img WHERE media_id IN (' . implode(",", $mediaIds) . ') ORDER BY position;';
         $images = Shopware()->Db()->query($sql)->fetchAll();
 

--- a/CseEightselectBasic/Components/FieldHelper.php
+++ b/CseEightselectBasic/Components/FieldHelper.php
@@ -51,12 +51,7 @@ class FieldHelper
                     $value = self::getUrl($article['articleID']);
                     break;
                 case 'bilder':
-                    $images = ArticleImageMapper::getImagesByVariant(
-                        $article['detailID'],
-                        $article['articleID']
-                    );
-
-                    $value = self::getImageUrls($images);
+                    $value = self::getImageUrls($article['detailID'], $article['articleID']);
                     break;
                 case 'status':
                     $value = self::getStatus($article['active'], $article['instock'], $article['laststock']);
@@ -189,18 +184,20 @@ class FieldHelper
     }
 
     /**
-     * @param  array $images
-     * @throws \Exception
+     * @param  int $detailId
+     * @param  int $articleId
      * @return string
      */
-    private static function getImageUrls($images)
+    private static function getImageUrls($detailId, $articleId)
     {
+        $imagePaths = ArticleImageMapper::getImagePathsByVariant($detailId, $articleId);
+
         /** @var MediaService $mediaService */
         $mediaService = Shopware()->Container()->get('shopware_media.media_service');
 
-        foreach ($images as $image) {
-            $path = 'media/image/' . $image['img'] . '.' . $image['extension'];
-            $urlArray[] = $mediaService->getUrl($path);
+        $urlArray = [];
+        foreach ($imagePaths as $imagePath) {
+            $urlArray[] = $mediaService->getUrl($imagePath['path']);
         }
 
         $urlString = implode('|', $urlArray);

--- a/CseEightselectBasic/Components/RunCronOnce.php
+++ b/CseEightselectBasic/Components/RunCronOnce.php
@@ -6,6 +6,15 @@ class RunCronOnce
     const TABLE_NAME = '8s_cron_run_once';
 
     public static function runOnce($cronName) {
+        if (self::isScheduled($cronName) || self::isRunning($cronName)) {
+            $message = 'Export nicht ausgeführt, es ist bereits ein Export in der Warteschleife.';
+            Shopware()->PluginLogger()->warning($message);
+            if (getenv('ES_DEBUG')) {
+                echo $message . PHP_EOL;
+            }
+            return;
+        }
+
         $connection = Shopware()->Container()->get('dbal_connection');
         $connection->insert(self::TABLE_NAME, ['cron_name' => $cronName, 'updated_at' => (new \DateTime())->format('Y-m-d H:i:s')]);
     }

--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -68,7 +68,7 @@
                 var descriptionContainer = descriptionDiv && descriptionDiv.parentNode && descriptionDiv.parentNode.parentNode
 
                 var cseTab = document.querySelector('a[data-tabname=cse]')
-                var cseDiv = document.querySelector('div.content--cse')
+                var cseDiv = document.querySelector('div.-eightselect-widget-container')
                 var cseContainer = cseDiv && cseDiv.parentNode && cseDiv.parentNode.parentNode
 
                 if (!descriptionTab || !cseTab || !descriptionContainer || !cseContainer) {
@@ -91,7 +91,7 @@
                 var descriptionContainer = descriptionDiv && descriptionDiv.parentNode && descriptionDiv.parentNode.parentNode
 
                 var cseTab = document.querySelector('a[data-tabname=cse]')
-                var cseDiv = document.querySelector('div.content--cse')
+                var cseDiv = document.querySelector('div.-eightselect-widget-container')
                 var cseContainer = cseDiv && cseDiv.parentNode && cseDiv.parentNode.parentNode
 
                 if (!descriptionTab || !cseTab || !descriptionContainer || !cseContainer) {


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/CSE-988

**Summary**
- added `ArticleImagerMapper` class that...
  - ...gets the current articles images by its ordernumber
  - ...checks the current article images for existing option mappings and matches them with the articles own options
   - will return the `img` and `extension` of any image which contains an option mapping that matches an option of its article / variant 
- sort images by their respective `position` (resolves https://8select.atlassian.net/browse/CSE-1036)
- reduced DB queries as far as possible by batch querying more data upfront
- remove unnecessary spaces around pipes between image urls

For more information on how option relations between articles an images are achieved, see JIRA ticket.

**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [x] Unit tests for new / changed logic exist OR no logic changes are passing

**Example Export see at:**
https://productfeed-prod.staging.8select.io.s3.amazonaws.com/150f0d73-ec87-4d25-8589-a2ac5a79be37/product_feed/2018/07/03/150f0d73-ec87-4d25-8589-a2ac5a79be37_product_feed_1530602366057.csv
