### PR TITLE
CSE-1096 add missing table names on standard mapping fields

### DIFF
--- a/CseEightselectBasic/Controllers/Backend/CseEightselectBasicAttributeConfig.php
+++ b/CseEightselectBasic/Controllers/Backend/CseEightselectBasicAttributeConfig.php
@@ -27,12 +27,12 @@ class Shopware_Controllers_Backend_CseEightselectBasicAttributeConfig extends \S
             ['column_name' => 's_articles.description_long', 'label' => 'Description long'],
             ['column_name' => 's_articles.keywords', 'label' => 'Keywords'],
             // details attributes
-            ['column_name' => 'additionaltext', 'label' => 'Additional text'],
-            ['column_name' => 'weight', 'label' => 'Weight'],
-            ['column_name' => 'width', 'label' => 'Width'],
-            ['column_name' => 'height', 'label' => 'Height'],
-            ['column_name' => 'length', 'label' => 'Length'],
-            ['column_name' => 'ean', 'label' => 'EAN'],
+            ['column_name' => 's_articles_details.additionaltext', 'label' => 'Additional text'],
+            ['column_name' => 's_articles_details.weight', 'label' => 'Weight'],
+            ['column_name' => 's_articles_details.width', 'label' => 'Width'],
+            ['column_name' => 's_articles_details.height', 'label' => 'Height'],
+            ['column_name' => 's_articles_details.length', 'label' => 'Length'],
+            ['column_name' => 's_articles_details.ean', 'label' => 'EAN'],
         ];
 
         $attributeData1 = Shopware()->Db()->query('SELECT `column_name`, label FROM s_attribute_configuration WHERE table_name = "s_articles_attributes"')->fetchAll();


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/CSE-1096

**Summary**

- added missing table names in `CseEightselectBasicAttributeConfig.php` Backend Controller

There are no selectable mapping fields without a corresponding table anymore now.

**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [x] Unit tests for new / changed logic exist OR no logic changes are passing
