### PR TITLE
CSE-1323 make entries in update queue unique

### DIFF
--- a/CseEightselectBasic/Components/ExportSetup.php
+++ b/CseEightselectBasic/Components/ExportSetup.php
@@ -5,10 +5,9 @@ class ExportSetup
 {
     public static function createChangeQueueTable() {
         $query = 'CREATE TABLE `8s_articles_details_change_queue` (
-            `id` int(11) NOT NULL AUTO_INCREMENT,
             `s_articles_details_id` int(11) NOT NULL,
             `updated_at` datetime,
-            PRIMARY KEY (`id`)
+            PRIMARY KEY (`s_articles_details_id`)
           ) COLLATE=\'utf8_unicode_ci\' ENGINE=InnoDB DEFAULT CHARSET=utf8;';
 
         Shopware()->Db()->query($query);
@@ -19,32 +18,32 @@ class ExportSetup
             AFTER UPDATE on `s_articles`
                 FOR EACH ROW
                 BEGIN
-                    INSERT INTO 8s_articles_details_change_queue (s_articles_details_id, updated_at)
-                    SELECT
-                        id as s_articles_details_id,
-                        NOW() as updated_at
-                    FROM s_articles_details
-                    WHERE articleID = NEW.id;
+                    REPLACE INTO 8s_articles_details_change_queue (s_articles_details_id, updated_at)
+                        SELECT
+                            id as s_articles_details_id,
+                            NOW() as updated_at
+                        FROM s_articles_details
+                        WHERE articleID = NEW.id;
                 END';
 
         $sArticlesDetailsTrigger = 'CREATE TRIGGER `8s_articles_details_change_queue_writer`
             AFTER UPDATE on `s_articles_details`
                 FOR EACH ROW
                 BEGIN
-                    INSERT INTO 8s_articles_details_change_queue (s_articles_details_id, updated_at)
-                    VALUES (NEW.id, NOW());
+                    REPLACE INTO 8s_articles_details_change_queue (s_articles_details_id, updated_at)
+                        VALUES (NEW.id, NOW());
                 END';
 
         $sArticlesImgTrigger = 'CREATE TRIGGER `8s_articles_img_change_queue_writer`
             AFTER UPDATE on `s_articles_img`
                 FOR EACH ROW
                 BEGIN
-                    INSERT INTO 8s_articles_details_change_queue (s_articles_details_id, updated_at)
-                    SELECT
-                        id as s_articles_details_id,
-                        NOW() as updated_at
-                    FROM s_articles_details
-                    WHERE articleID = NEW.articleID;
+                    REPLACE INTO 8s_articles_details_change_queue (s_articles_details_id, updated_at)
+                        SELECT
+                            id as s_articles_details_id,
+                            NOW() as updated_at
+                        FROM s_articles_details
+                        WHERE articleID = NEW.articleID;
                 END';
 
         $sArticlesPricesTrigger = 'CREATE TRIGGER `8s_s_articles_prices_change_queue_writer`
@@ -54,8 +53,8 @@ class ExportSetup
                     IF (NEW.price != OLD.price
                     OR NEW.pseudoprice != OLD.pseudoprice)
                     THEN
-                        INSERT INTO 8s_articles_details_change_queue (s_articles_details_id, updated_at)
-                        VALUES (NEW.articleDetailsID, NOW());
+                        REPLACE INTO 8s_articles_details_change_queue (s_articles_details_id, updated_at)
+                            VALUES (NEW.articleDetailsID, NOW());
                     END IF;
                   END';
 
@@ -63,23 +62,23 @@ class ExportSetup
             AFTER UPDATE on `s_articles_attributes`
                 FOR EACH ROW
                 BEGIN
-                    INSERT INTO 8s_articles_details_change_queue (s_articles_details_id, updated_at)
-                    VALUES (NEW.articleDetailsID, NOW());
+                    REPLACE INTO 8s_articles_details_change_queue (s_articles_details_id, updated_at)
+                        VALUES (NEW.articleDetailsID, NOW());
                 END';
 
         $sArticleConfiguratorOptionRelationsTrigger = 'CREATE TRIGGER `8s_s_article_configurator_option_relations_change_queue_writer`
             AFTER UPDATE on `s_article_configurator_option_relations`
-                  FOR EACH ROW
-                  BEGIN
-                      INSERT INTO 8s_articles_details_change_queue (s_articles_details_id, updated_at)
-                      VALUES (NEW.article_id, NOW());
-                  END';
+                FOR EACH ROW
+                BEGIN
+                    REPLACE INTO 8s_articles_details_change_queue (s_articles_details_id, updated_at)
+                        VALUES (NEW.article_id, NOW());
+                END';
 
         $sArticleImgMappingsTrigger = 'CREATE TRIGGER `8s_s_article_img_mappings_change_queue_writer`
             AFTER UPDATE on `s_article_img_mappings`
                 FOR EACH ROW
                 BEGIN
-                    INSERT INTO 8s_articles_details_change_queue (s_articles_details_id, updated_at)
+                    REPLACE INTO 8s_articles_details_change_queue (s_articles_details_id, updated_at)
                         SELECT
                             ad.id as s_articles_details_id,
                             NOW() as updated_at
@@ -92,7 +91,7 @@ class ExportSetup
             AFTER UPDATE on `s_article_img_mapping_rules`
                   FOR EACH ROW
                   BEGIN
-                    INSERT INTO 8s_articles_details_change_queue (s_articles_details_id, updated_at)
+                    REPLACE INTO 8s_articles_details_change_queue (s_articles_details_id, updated_at)
                         SELECT
                             ad.id as s_articles_details_id,
                             NOW() as updated_at
@@ -106,14 +105,14 @@ class ExportSetup
         AFTER UPDATE on `s_articles_supplier`
             FOR EACH ROW
             BEGIN
-                INSERT INTO 8s_articles_details_change_queue (s_articles_details_id, updated_at)
-                SELECT
-                    ad.id as s_articles_details_id,
-                    NOW() as updated_at
-                FROM s_articles_supplier asu
-                INNER JOIN s_articles a ON a.supplierID = asu.id
-                INNER JOIN s_articles_details ad ON ad.articleID = a.id
-                WHERE asu.id = NEW.id;
+                REPLACE INTO 8s_articles_details_change_queue (s_articles_details_id, updated_at)
+                    SELECT
+                        ad.id as s_articles_details_id,
+                        NOW() as updated_at
+                    FROM s_articles_supplier asu
+                    INNER JOIN s_articles a ON a.supplierID = asu.id
+                    INNER JOIN s_articles_details ad ON ad.articleID = a.id
+                    WHERE asu.id = NEW.id;
             END';
 
         $triggerQueries = [

--- a/CseEightselectBasic/CseEightselectBasic.php
+++ b/CseEightselectBasic/CseEightselectBasic.php
@@ -212,6 +212,8 @@ class CseEightselectBasic extends Plugin
                 $this->update_1_5_0();
             case version_compare($context->getCurrentVersion(), '1.5.2', '<='):
                 $this->update_1_5_2();
+            case version_compare($context->getCurrentVersion(), '1.6.3', '<='):
+                $this->update_1_6_3();
         }
     }
 
@@ -237,6 +239,15 @@ class CseEightselectBasic extends Plugin
         $this->addPropertyOnceCron();
         // update changeQueue triggers
         ExportSetup::dropChangeQueueTriggers();
+        ExportSetup::createChangeQueueTriggers();
+    }
+
+    private function update_1_6_3()
+    {
+        // update changeQueue table and triggers
+        ExportSetup::dropChangeQueueTriggers();
+        ExportSetup::dropChangeQueueTable();
+        ExportSetup::createChangeQueueTable();
         ExportSetup::createChangeQueueTriggers();
     }
 


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/CSE-1323

**Summary**

before this change every trigger added a row in the update queue table

this can result in quadtrillion entries that take much disk space if the
propert_export cron was not working, i.e. the table was never emptied

with this change the max number of entries equals the entries in the
s_articles_details table and therefor the table needs less memory than
the s_articles_details table because there are only 2 rows to fill

<!--
You can assign a team-member to review the PR.
If you are confident that no critical system breaks you can merge without a review.
-->
**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [ ] Unit tests for new / changed logic exist OR no logic changes are passing
