### PR TITLE
CSE-1326 fix tab navigation

### DIFF
--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -63,13 +63,18 @@
     {if {config name="8s_selected_detail_block"} == "frontend_detail_tabs"}
         {* Activate description tab - SYS tab will be activated when CSE finds a set *}
         <script type="text/javascript">
+             _eightselect_shop_plugin.setPreviouslyActiveTab = function () {
+                _eightselect_shop_plugin.previouslyActiveTab = document.querySelector('a.tab--link.has--content.is--active')
+                return _eightselect_shop_plugin.previouslyActiveTab
+            }
+
             _eightselect_shop_plugin.getPreviouslyActiveTab = function () {
                 _eightselect_shop_plugin.previouslyActiveTab = _eightselect_shop_plugin.previouslyActiveTab || document.querySelector('a.tab--link.has--content.is--active')
                 return _eightselect_shop_plugin.previouslyActiveTab
             }
 
-            _eightselect_shop_plugin.getPreviouslyActiveTabContent = function () {
-                _eightselect_shop_plugin.previouslyActiveTabContent = _eightselect_shop_plugin.previouslyActiveTabContent || document.querySelector('div.tab--container.has--content.is--active')
+            _eightselect_shop_plugin.setPreviouslyActiveTabContent = function () {
+                _eightselect_shop_plugin.previouslyActiveTabContent = document.querySelector('div.tab--container.has--content.is--active')
                 return _eightselect_shop_plugin.previouslyActiveTabContent
             }
 
@@ -91,11 +96,14 @@
             };
 
             _eightselect_shop_plugin.showSys = function () {
+                var previouslyActiveTab = _eightselect_shop_plugin.setPreviouslyActiveTab()
+                var previouslyActiveTabContent = _eightselect_shop_plugin.setPreviouslyActiveTabContent()
+
                 var cseTab = document.querySelector('a[data-tabname=cse]')
                 var cseDiv = document.querySelector('div.-eightselect-widget-container')
                 var cseContainer = cseDiv && cseDiv.parentNode && cseDiv.parentNode.parentNode
 
-                if (!cseTab || !cseContainer) {
+                if (!previouslyActiveTab || !cseTab || !previouslyActiveTabContent || !cseContainer) {
                     return;
                 }
 

--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -63,7 +63,7 @@
     {if {config name="8s_selected_detail_block"} == "frontend_detail_tabs"}
         {* Activate description tab - SYS tab will be activated when CSE finds a set *}
         <script type="text/javascript">
-             _eightselect_shop_plugin.setPreviouslyActiveTab = function () {
+            _eightselect_shop_plugin.setPreviouslyActiveTab = function () {
                 _eightselect_shop_plugin.previouslyActiveTab = document.querySelector('a.tab--link.has--content.is--active')
                 return _eightselect_shop_plugin.previouslyActiveTab
             }
@@ -74,10 +74,11 @@
             }
 
             _eightselect_shop_plugin.hideSys = function () {
+                var previouslyActiveTab = _eightselect_shop_plugin.getPreviouslyActiveTab()
+                
                 var cseTab = document.querySelector('a[data-tabname=cse]')
                 var cseDiv = document.querySelector('div.-eightselect-widget-container')
                 var cseContainer = cseDiv && cseDiv.parentNode && cseDiv.parentNode.parentNode
-                var previouslyActiveTab = _eightselect_shop_plugin.getPreviouslyActiveTab()
 
                 if (!previouslyActiveTab || !cseTab || !cseContainer) {
                     return;

--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -73,11 +73,6 @@
                 return _eightselect_shop_plugin.previouslyActiveTabContent
             }
 
-            _eightselect_shop_plugin.doClick = function (elem) {
-                var evt = new MouseEvent('click');
-                var canceled = !elem.dispatchEvent(evt);
-            };
-
             _eightselect_shop_plugin.hideSys = function () {
                 var previouslyActiveTab = _eightselect_shop_plugin.getPreviouslyActiveTab()
 
@@ -89,7 +84,7 @@
                     return;
                 }
 
-                _eightselect_shop_plugin.doClick(previouslyActiveTab)
+                previouslyActiveTab.click()
 
                 cseTab.style.display = 'none'
                 cseContainer.style.display = 'none'
@@ -104,7 +99,7 @@
                     return;
                 }
 
-                _eightselect_shop_plugin.doClick(cseTab)
+                cseTab.click()
 
                 cseTab.style.display = ''
                 cseContainer.style.display = ''

--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -79,8 +79,6 @@
             }
 
             _eightselect_shop_plugin.hideSys = function () {
-                var previouslyActiveTab = _eightselect_shop_plugin.getPreviouslyActiveTab()
-
                 var cseTab = document.querySelector('a[data-tabname=cse]')
                 var cseDiv = document.querySelector('div.-eightselect-widget-container')
                 var cseContainer = cseDiv && cseDiv.parentNode && cseDiv.parentNode.parentNode
@@ -89,21 +87,18 @@
                     return;
                 }
 
-                previouslyActiveTab.click()
+                _eightselect_shop_plugin.getPreviouslyActiveTab().click()
 
                 cseTab.style.display = 'none'
                 cseContainer.style.display = 'none'
             };
 
             _eightselect_shop_plugin.showSys = function () {
-                var previouslyActiveTab = _eightselect_shop_plugin.setPreviouslyActiveTab()
-                var previouslyActiveTabContent = _eightselect_shop_plugin.setPreviouslyActiveTabContent()
-
                 var cseTab = document.querySelector('a[data-tabname=cse]')
                 var cseDiv = document.querySelector('div.-eightselect-widget-container')
                 var cseContainer = cseDiv && cseDiv.parentNode && cseDiv.parentNode.parentNode
 
-                if (!previouslyActiveTab || !cseTab || !previouslyActiveTabContent || !cseContainer) {
+                if (!_eightselect_shop_plugin.setPreviouslyActiveTab() || !cseTab || !_eightselect_shop_plugin.setPreviouslyActiveTabContent() || !cseContainer) {
                     return;
                 }
 

--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -73,21 +73,17 @@
                 return _eightselect_shop_plugin.previouslyActiveTab
             }
 
-            _eightselect_shop_plugin.setPreviouslyActiveTabContent = function () {
-                _eightselect_shop_plugin.previouslyActiveTabContent = document.querySelector('div.tab--container.has--content.is--active')
-                return _eightselect_shop_plugin.previouslyActiveTabContent
-            }
-
             _eightselect_shop_plugin.hideSys = function () {
                 var cseTab = document.querySelector('a[data-tabname=cse]')
                 var cseDiv = document.querySelector('div.-eightselect-widget-container')
                 var cseContainer = cseDiv && cseDiv.parentNode && cseDiv.parentNode.parentNode
+                var previouslyActiveTab = _eightselect_shop_plugin.getPreviouslyActiveTab()
 
-                if (!cseTab || !cseContainer) {
+                if (!previouslyActiveTab || !cseTab || !cseContainer) {
                     return;
                 }
 
-                _eightselect_shop_plugin.getPreviouslyActiveTab().click()
+                previouslyActiveTab.click()
 
                 cseTab.style.display = 'none'
                 cseContainer.style.display = 'none'
@@ -98,7 +94,7 @@
                 var cseDiv = document.querySelector('div.-eightselect-widget-container')
                 var cseContainer = cseDiv && cseDiv.parentNode && cseDiv.parentNode.parentNode
 
-                if (!_eightselect_shop_plugin.setPreviouslyActiveTab() || !cseTab || !_eightselect_shop_plugin.setPreviouslyActiveTabContent() || !cseContainer) {
+                if (!_eightselect_shop_plugin.setPreviouslyActiveTab() || !cseTab || !cseContainer) {
                     return;
                 }
 

--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -77,7 +77,7 @@
                 var evt = new MouseEvent('click');
                 var canceled = !elem.dispatchEvent(evt);
             };
-      
+
             _eightselect_shop_plugin.hideSys = function () {
                 var previouslyActiveTab = _eightselect_shop_plugin.getPreviouslyActiveTab()
                 var previouslyActiveTabContent = _eightselect_shop_plugin.getPreviouslyActiveTabContent()

--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -63,13 +63,6 @@
     {if {config name="8s_selected_detail_block"} == "frontend_detail_tabs"}
         {* Activate description tab - SYS tab will be activated when CSE finds a set *}
         <script type="text/javascript">
-            _eightselect_shop_plugin.isActiveClass = 'is--active'
-
-            _eightselect_shop_plugin.setPreviouslyActiveTab = function () {
-                _eightselect_shop_plugin.previouslyActiveTab = document.querySelector('a.tab--link.has--content.is--active')
-                return _eightselect_shop_plugin.previouslyActiveTab
-            }
-
             _eightselect_shop_plugin.getPreviouslyActiveTab = function () {
                 _eightselect_shop_plugin.previouslyActiveTab = _eightselect_shop_plugin.previouslyActiveTab || document.querySelector('a.tab--link.has--content.is--active')
                 return _eightselect_shop_plugin.previouslyActiveTab
@@ -80,11 +73,11 @@
                 return _eightselect_shop_plugin.previouslyActiveTabContent
             }
 
-            _eightselect_shop_plugin.setPreviouslyActiveTabContent = function () {
-                _eightselect_shop_plugin.previouslyActiveTabContent = document.querySelector('div.tab--container.has--content.is--active')
-                return _eightselect_shop_plugin.previouslyActiveTabContent
-            }
-
+            _eightselect_shop_plugin.doClick = function (elem) {
+                var evt = new MouseEvent('click');
+                var canceled = !elem.dispatchEvent(evt);
+            };
+      
             _eightselect_shop_plugin.hideSys = function () {
                 var previouslyActiveTab = _eightselect_shop_plugin.getPreviouslyActiveTab()
                 var previouslyActiveTabContent = _eightselect_shop_plugin.getPreviouslyActiveTabContent()
@@ -93,37 +86,26 @@
                 var cseDiv = document.querySelector('div.-eightselect-widget-container')
                 var cseContainer = cseDiv && cseDiv.parentNode && cseDiv.parentNode.parentNode
 
-                if (!previouslyActiveTab || !cseTab || !previouslyActiveTabContent || !cseContainer) {
+                if (!cseTab || !cseContainer) {
                     return;
                 }
 
-                previouslyActiveTab.classList.add(_eightselect_shop_plugin.isActiveClass)
-                previouslyActiveTabContent.classList.add(_eightselect_shop_plugin.isActiveClass)
-
-                cseTab.classList.remove(_eightselect_shop_plugin.isActiveClass)
-                cseContainer.classList.remove(_eightselect_shop_plugin.isActiveClass)
+                _eightselect_shop_plugin.doClick(previouslyActiveTab)
 
                 cseTab.style.display = 'none'
                 cseContainer.style.display = 'none'
             };
 
             _eightselect_shop_plugin.showSys = function () {
-                var previouslyActiveTab = _eightselect_shop_plugin.setPreviouslyActiveTab()
-                var previouslyActiveTabContent = _eightselect_shop_plugin.setPreviouslyActiveTabContent()
-
                 var cseTab = document.querySelector('a[data-tabname=cse]')
                 var cseDiv = document.querySelector('div.-eightselect-widget-container')
                 var cseContainer = cseDiv && cseDiv.parentNode && cseDiv.parentNode.parentNode
 
-                if (!previouslyActiveTab || !cseTab || !previouslyActiveTabContent || !cseContainer) {
+                if (!cseTab || !cseContainer) {
                     return;
                 }
 
-                previouslyActiveTab.classList.remove(_eightselect_shop_plugin.isActiveClass)
-                previouslyActiveTabContent.classList.remove(_eightselect_shop_plugin.isActiveClass)
-
-                cseTab.classList.add(_eightselect_shop_plugin.isActiveClass)
-                cseContainer.classList.add(_eightselect_shop_plugin.isActiveClass)
+                _eightselect_shop_plugin.doClick(cseTab)
 
                 cseTab.style.display = ''
                 cseContainer.style.display = ''

--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -80,7 +80,6 @@
 
             _eightselect_shop_plugin.hideSys = function () {
                 var previouslyActiveTab = _eightselect_shop_plugin.getPreviouslyActiveTab()
-                var previouslyActiveTabContent = _eightselect_shop_plugin.getPreviouslyActiveTabContent()
 
                 var cseTab = document.querySelector('a[data-tabname=cse]')
                 var cseDiv = document.querySelector('div.-eightselect-widget-container')


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/CSE-1326

**Summary**
- dispatch `MouseEvent('click')` on active Tab as soon as DOM is ready and SYS endpoint responded
- removed active Tab setter by `elem.classList` attribute

**Notes**
Previously we have set the active tab by manipulating the `classList` attribute on the Tab DOM element we wanted to activate. However this didn't seem to convince the existing tab navigation logic of another tab being activated, which resulted in the user not being able to activate the first tab (which internally was already the active one). By dispatching an actual click event on our target tab we trigger the native tab navigation logic instead of implementing our own. 

**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [x] Unit tests for new / changed logic exist OR no logic changes are passing
