### PR TITLE
CSE-1351 only use default pricegroup

### DIFF
--- a/CseEightselectBasic/Components/Export.php
+++ b/CseEightselectBasic/Components/Export.php
@@ -201,7 +201,7 @@ abstract class Export
                     INNER JOIN s_articles_details AS ad2 ON ad2.articleID = s_articles_details.articleID AND ad2.kind = 1
                     INNER JOIN s_articles ON s_articles.id = s_articles_details.articleID
                     INNER JOIN s_articles_attributes ON s_articles_attributes.articledetailsID = s_articles_details.id
-                    INNER JOIN s_articles_prices ON s_articles_prices.articledetailsID = s_articles_details.id AND s_articles_prices.from = 1
+                    INNER JOIN s_articles_prices ON s_articles_prices.articledetailsID = s_articles_details.id AND s_articles_prices.from = 1 AND s_articles_prices.pricegroup = "EK"
                     INNER JOIN s_articles_supplier ON s_articles_supplier.id = s_articles.supplierID
                     INNER JOIN s_core_tax ON s_core_tax.id = s_articles.taxID
                 LIMIT %d OFFSET %d';


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/CSE-1351

**Summary**

* you can define price/customer groups in shopware
* a product can have different prices for each of those groups
* this PR limits the used price to the default group, otherwise we export multiple lines per product

<!--
You can assign a team-member to review the PR.
If you are confident that no critical system breaks you can merge without a review.
-->
**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [x] Unit tests for new / changed logic exist OR no logic changes are passing
