### PR TITLE
CSE-1362 initially call hideSys() to make default tab active

### DIFF
--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -103,6 +103,7 @@
 
             var domListener = function () {
                 window.removeEventListener('DOMContentLoaded', domListener);
+                _eightselect_shop_plugin.hideSys();
             };
 
             if (window.document.readyState !== 'loading') {


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/CSE-1362

**Summary**

* hide sys tab on startup
* excluding scripts / templates based on preview mode is very complicated, because if statements can only exist inside smarty `block` elements - that would result in massive amounts of if statements, this is the "easy" way

<!--
You can assign a team-member to review the PR.
If you are confident that no critical system breaks you can merge without a review.
-->
**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [ ] Unit tests for new / changed logic exist OR no logic changes are passing
