### PR TITLE
CSE-1570 prevent multiple cart events

### DIFF
--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -59,10 +59,33 @@
             var _eightselect_shop_plugin = {};
         }
         _eightselect_shop_plugin.addToCart = function (sku, quantity, Promise) {
+
+            var swStandardCartForm = document.querySelector('.buybox--form') || document.querySelector('form[name="sAddToBasket"]');
+            var eightSelectCartForm = document.getElementById('eightselect_cart_trigger_form');
+
+            if (swStandardCartForm) {
+                var skuBefore = document.querySelector('.buybox--form input[name="sAdd"]').value;
+                var quantityBefore = document.querySelector('.buybox--form select[name="sQuantity"]').value;
+                
+                eightSelectCartForm.setAttribute("data-add-article", "false");
+
+                document.querySelector('.buybox--form input[name="sAdd"]').value = sku;
+                document.querySelector('.buybox--form select[name="sQuantity"]').value = "1";
+                document.querySelector('.buybox--button').click();
+
+                // reset to values before form manipulation for widget
+                document.querySelector('.buybox--form input[name="sAdd"]').value = skuBefore;
+                document.querySelector('.buybox--form select[name="sQuantity"]').value = quantityBefore;
+
+                return Promise.resolve();
+            }
+
+            eightSelectCartForm.setAttribute("data-add-article", "true");
+
             document.getElementById('eightselect_cart_trigger_form_sku').value = sku;
             document.getElementById('eightselect_cart_trigger_form_quantity').value = quantity;
             document.getElementById('eightselect_cart_trigger_form_submit').click();
-
+        
             return Promise.resolve();
         };
 

--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -58,43 +58,62 @@
         if (typeof _eightselect_shop_plugin === "undefined") {
             var _eightselect_shop_plugin = {};
         }
-        _eightselect_shop_plugin.addToCart = function (sku, quantity, Promise) {
-
-            var swStandardCartForm = document.querySelector('.buybox--form') || document.querySelector('form[name="sAddToBasket"]');
-            var eightSelectCartForm = document.getElementById('eightselect_cart_trigger_form');
-
-            if (swStandardCartForm) {
-                var skuBefore = document.querySelector('.buybox--form input[name="sAdd"]').value;
-                var quantityBefore = document.querySelector('.buybox--form select[name="sQuantity"]').value;
-                
-                eightSelectCartForm.setAttribute("data-add-article", "false");
-
-                document.querySelector('.buybox--form input[name="sAdd"]').value = sku;
-                document.querySelector('.buybox--form select[name="sQuantity"]').value = "1";
-                document.querySelector('.buybox--button').click();
-
-                // reset to values before form manipulation for widget
-                document.querySelector('.buybox--form input[name="sAdd"]').value = skuBefore;
-                document.querySelector('.buybox--form select[name="sQuantity"]').value = quantityBefore;
-
-                return Promise.resolve();
-            }
-
-            eightSelectCartForm.setAttribute("data-add-article", "true");
-
-            document.getElementById('eightselect_cart_trigger_form_sku').value = sku;
-            document.getElementById('eightselect_cart_trigger_form_quantity').value = quantity;
-            document.getElementById('eightselect_cart_trigger_form_submit').click();
-
-            return Promise.resolve();
-        };
-
+        
         _eightselect_shop_plugin.showSys = function () {
             return;
         };
         _eightselect_shop_plugin.hideSys = function () {
             return;
         };
+
+        document.addEventListener('DOMContentLoaded', function (){
+            var swStandardCartForm = document.querySelectorAll('.buybox--form', 'form[name="sAddToBasket"]')[0];
+            var eightselectCartForm = document.getElementById('eightselect_cart_trigger_form');
+
+            _eightselect_shop_plugin.isStandardCartFormPresent = function() {
+                return !!swStandardCartForm;
+            };
+
+            _eightselect_shop_plugin.disableEightselectCartForm = function() {
+                return eightselectCartForm.setAttribute("data-add-article", "false");
+            };
+
+            _eightselect_shop_plugin.enableEightselectCartForm = function() {
+                return eightselectCartForm.setAttribute("data-add-article", "true");
+            };
+
+            _eightselect_shop_plugin.useStandardCartForm = function(sku) {
+                var skuBefore = swStandardCartForm.querySelector('input[name="sAdd"]').value;
+                var quantityBefore = swStandardCartForm.querySelector('select[name="sQuantity"]').value;
+
+                swStandardCartForm.querySelector('input[name="sAdd"]').value = sku;
+                swStandardCartForm.querySelector('select[name="sQuantity"]').value = "1";
+                swStandardCartForm.querySelector('.buybox--button').click();
+
+                swStandardCartForm.querySelector('input[name="sAdd"]').value = skuBefore;
+                swStandardCartForm.querySelector('select[name="sQuantity"]').value = quantityBefore;
+            };
+
+            _eightselect_shop_plugin.useEightselectCartForm = function(sku, quantity) {
+                eightselectCartForm.getElementById('eightselect_cart_trigger_form_sku').value = sku;
+                eightselectCartForm.getElementById('eightselect_cart_trigger_form_quantity').value = quantity;
+                eightselectCartForm.getElementById('eightselect_cart_trigger_form_submit').click();
+            };
+
+            _eightselect_shop_plugin.addToCart = function (sku, quantity, Promise) {
+                if (_eightselect_shop_plugin.isStandardCartFormPresent()) {
+                    _eightselect_shop_plugin.disableEightselectCartForm()
+                    _eightselect_shop_plugin.useStandardCartForm(sku)
+
+                    return Promise.resolve();
+                }
+
+                _eightselect_shop_plugin.enableEightselectCartForm()
+                _eightselect_shop_plugin.useEightselectCartForm(sku, quantity)
+
+                return Promise.resolve();
+            };
+        })
     </script>
 
     {if {config name="8s_selected_detail_block"} == "frontend_detail_tabs"}

--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -85,7 +85,7 @@
             document.getElementById('eightselect_cart_trigger_form_sku').value = sku;
             document.getElementById('eightselect_cart_trigger_form_quantity').value = quantity;
             document.getElementById('eightselect_cart_trigger_form_submit').click();
-        
+
             return Promise.resolve();
         };
 


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/CSE-1570

**Summary**

- we check for standard shopware cart form to exist and if so, use it for cart events of our widget
- use our own `eightselect_cart_trigger_form` only if no standard shopware cart form is available

Using the standard shopware cart if possible prevents other third party Shopware Plugins that may manipulate cart evetns from interfering with our very own cart form.

**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [ ] Unit tests for new / changed logic exist OR no logic changes are passing

+ tested with [Custom Products ](https://store.shopware.com/swagcustomproducts/custom-products.html)Plugin in Staging Testshop
+ tested without Shopware Standrad cart form (Einkaufswelten Integration)