### PR TITLE
CSE-1590 add our cart form without swAddArticle plugin triggers

### DIFF
--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -58,7 +58,7 @@
         if (typeof _eightselect_shop_plugin === "undefined") {
             var _eightselect_shop_plugin = {};
         }
-        
+
         _eightselect_shop_plugin.showSys = function () {
             return;
         };
@@ -66,54 +66,28 @@
             return;
         };
 
-        document.addEventListener('DOMContentLoaded', function (){
-            var swStandardCartForm = document.querySelectorAll('.buybox--form', 'form[name="sAddToBasket"]')[0];
-            var eightselectCartForm = document.querySelector('#eightselect_cart_trigger_form');
-
-            _eightselect_shop_plugin.isStandardCartFormPresent = function() {
-                return !!swStandardCartForm;
-            };
-
-            _eightselect_shop_plugin.disableEightselectCartForm = function() {
-                return eightselectCartForm.setAttribute("data-add-article", "false");
-            };
-
-            _eightselect_shop_plugin.enableEightselectCartForm = function() {
-                return eightselectCartForm.setAttribute("data-add-article", "true");
-            };
-
-            _eightselect_shop_plugin.useStandardCartForm = function(sku) {
-                var skuBefore = swStandardCartForm.querySelector('input[name="sAdd"]').value;
-                var quantityBefore = swStandardCartForm.querySelector('select[name="sQuantity"]').value;
-
-                swStandardCartForm.querySelector('input[name="sAdd"]').value = sku;
-                swStandardCartForm.querySelector('select[name="sQuantity"]').value = "1";
-                swStandardCartForm.querySelector('.buybox--button').click();
-
-                swStandardCartForm.querySelector('input[name="sAdd"]').value = skuBefore;
-                swStandardCartForm.querySelector('select[name="sQuantity"]').value = quantityBefore;
-            };
-
-            _eightselect_shop_plugin.useEightselectCartForm = function(sku, quantity) {
+        _eightselect_shop_plugin.addToCart = function (sku, quantity, Promise) {
+            try {
+                var eightselectCartForm = document.querySelector('#eightselect_cart_trigger_form');
+                eightselectCartForm.querySelector('#eightselect_cart_trigger_form_sku').setAttribute('name', 'sAdd');
+                eightselectCartForm.querySelector('#eightselect_cart_trigger_form_quantity').setAttribute('name', 'sQuantity');
                 eightselectCartForm.querySelector('#eightselect_cart_trigger_form_sku').value = sku;
                 eightselectCartForm.querySelector('#eightselect_cart_trigger_form_quantity').value = quantity;
+
+                $('#eightselect_cart_trigger_form').swAddArticle();
+
                 eightselectCartForm.querySelector('#eightselect_cart_trigger_form_submit').click();
-            };
 
-            _eightselect_shop_plugin.addToCart = function (sku, quantity, Promise) {
-                if (_eightselect_shop_plugin.isStandardCartFormPresent()) {
-                    _eightselect_shop_plugin.disableEightselectCartForm()
-                    _eightselect_shop_plugin.useStandardCartForm(sku)
-
-                    return Promise.resolve();
-                }
-
-                _eightselect_shop_plugin.enableEightselectCartForm()
-                _eightselect_shop_plugin.useEightselectCartForm(sku, quantity)
+                eightselectCartForm.querySelector('#eightselect_cart_trigger_form_sku').setAttribute('name', '');
+                eightselectCartForm.querySelector('#eightselect_cart_trigger_form_quantity').setAttribute('name', '');
 
                 return Promise.resolve();
-            };
-        })
+            } catch (error) {
+                console.log('8select add2cart logic failed');
+                console.log(error);
+                return Promise.reject(error);
+            }
+        };
     </script>
 
     {if {config name="8s_selected_detail_block"} == "frontend_detail_tabs"}

--- a/CseEightselectBasic/Resources/views/frontend/index/index.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/index.tpl
@@ -3,9 +3,9 @@
 {block name="frontend_index_after_body"}
     {$smarty.block.parent}
     {if !$checkoutFinish}
-        <form style="display:none;" id="eightselect_cart_trigger_form" method="post" action="{url controller=checkout action=addArticle}" data-add-article="true" data-eventName="submit" {if $theme.offcanvasCart} data-showModal="false" data-addArticleUrl="{url controller=checkout action=ajaxAddArticleCart}"{/if}>
-            <input id="eightselect_cart_trigger_form_sku" type="hidden" name="sAdd" value="placeholder">
-            <input id="eightselect_cart_trigger_form_quantity" type="hidden" name="sQuantity" value="1">
+        <form style="display:none;" id="eightselect_cart_trigger_form" method="post" action="{url controller=checkout action=addArticle}" data-eventName="submit" {if $theme.offcanvasCart} data-showModal="false" data-addArticleUrl="{url controller=checkout action=ajaxAddArticleCart}"{/if}>
+            <input id="eightselect_cart_trigger_form_sku" type="hidden" name="" value="placeholder">
+            <input id="eightselect_cart_trigger_form_quantity" type="hidden" name="" value="1">
             <button id="eightselect_cart_trigger_form_submit"></button>
         </form>
     {/if}


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/CSE-1590

**Summary**

* currently our cart logic interferes with plugins that also make use of the default shopware cart form
* instead of adding a second active cart form we now initially add our cart form without swAddArticle plugin triggers and without named input elements for ordernumber `sAdd` and quantitiy `sQuantity`
* the correct configuration and the `swAddArticle()` plugin are triggered while something is added to
the cart via our widgets now - our cart form is reset afterwards to avoid any inteference with other plugins
* incomplete list of plugins that intefered with the old logic:
  * Custom Products
  * Produkt Bundles

<!--
You can assign a team-member to review the PR.
If you are confident that no critical system breaks you can merge without a review.
-->
**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [x] Unit tests for new / changed logic exist OR no logic changes are passing
