### PR TITLE
CSE-1617 use absolute paths for temporary CSV storages

### DIFF
--- a/CseEightselectBasic/Components/ArticleExport.php
+++ b/CseEightselectBasic/Components/ArticleExport.php
@@ -9,7 +9,7 @@ use CseEightselectBasic\Components\Export;
 
 class ArticleExport extends Export
 {
-    const STORAGE = 'files/8select/';
+    const STORAGE = __DIR__ . '/files/8select/';
 
     const CRON_NAME = '8select_article_export';
 

--- a/CseEightselectBasic/Components/Export.php
+++ b/CseEightselectBasic/Components/Export.php
@@ -1,8 +1,8 @@
 <?php
 namespace CseEightselectBasic\Components;
 
+use SplFileInfo;
 use League\Csv\Writer;
-use Symfony\Component\Finder\SplFileInfo;
 use CseEightselectBasic\Components\Config;
 use CseEightselectBasic\Components\ConfigValidator;
 use CseEightselectBasic\Components\FeedLogger;

--- a/CseEightselectBasic/Components/Export.php
+++ b/CseEightselectBasic/Components/Export.php
@@ -2,6 +2,7 @@
 namespace CseEightselectBasic\Components;
 
 use League\Csv\Writer;
+use Symfony\Component\Finder\SplFileInfo;
 use CseEightselectBasic\Components\Config;
 use CseEightselectBasic\Components\ConfigValidator;
 use CseEightselectBasic\Components\FeedLogger;
@@ -129,14 +130,15 @@ abstract class Export
             require_once __DIR__ . '/../vendor/autoload.php';
         }
 
-        $csvWriter = Writer::createFromPath(static::STORAGE . $filename, 'a');
+        $tempPath = new SplFileInfo(static::STORAGE);
+        $csvWriter = Writer::createFromPath($tempPath->getPath() . $filename, 'a');
         $csvWriter->setDelimiter(';');
 
         $csvWriter->insertOne($this->header);
 
         $this->writeFile($csvWriter);
 
-        AWSUploader::upload($filename, static::STORAGE, $feedId, static::FEED_TYPE);
+        AWSUploader::upload($filename, $tempPath->getPath(), $feedId, static::FEED_TYPE);
     }
 
     /**

--- a/CseEightselectBasic/Components/PropertyExport.php
+++ b/CseEightselectBasic/Components/PropertyExport.php
@@ -7,7 +7,7 @@ use CseEightselectBasic\Components\RunCronOnce;
 
 class PropertyExport extends Export
 {
-    const STORAGE = 'files/8select/';
+    const STORAGE = __DIR__ . '/files/8select/';
 
     const FEED_TYPE = 'property_feed';
 


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/CSE-1617

**Summary**
- use `__DIR__` to set path for `STORAGE` constants absolute
- read `STORAGE` path via [`SplFileInfo::getPath()`](http://php.net/manual/de/splfileinfo.getpath.php) since passing the absolute `STORAGE` as a string apparently creates an `RuntimeException: SplFileObject::__construct()` error

Since we're not able to recreate the customer circumstances where the original error occurs, I can't assure that this fixes anything. It might at best just prevent possible misbehaviors. 

**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [ ] Unit tests for new / changed logic exist OR no logic changes are passing

**Dump of path used to create temp CSV file before this change:**
![bildschirmfoto 2018-11-23 um 14 15 34](https://user-images.githubusercontent.com/1707307/48945695-8c395580-ef2b-11e8-84a5-2c812f040c30.png)

**After this change:**
![bildschirmfoto 2018-11-23 um 14 13 22](https://user-images.githubusercontent.com/1707307/48945698-8d6a8280-ef2b-11e8-8634-19d13e6ae0e4.png)
