### PR TITLE
CSE-1617 use temp file created by PHP

### DIFF
--- a/CseEightselectBasic/Components/AWSUploader.php
+++ b/CseEightselectBasic/Components/AWSUploader.php
@@ -6,23 +6,23 @@ use Aws\S3\S3Client;
 class AWSUploader
 {
     /**
-     * @param  string $filename
-     * @param  string $storage
-     * @param  string $feedId
+     * @param  string $path
      * @param  string $feedType
      * @throws \Enlight_Exception
      */
-    public static function upload($filename, $storage, $feedId, $feedType)
+    public static function upload($path, $feedType)
     {
         // needs to be loaded here, because Shopware and AWS use different versions of Guzzle
         if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
             require_once __DIR__ . '/../vendor/autoload.php';
         }
-
-        $bucket = '__SUBDOMAIN__.8select.io';
-        $region = 'eu-central-1';
+        $config = Shopware()->Container()->get('shopware.plugin.cached_config_reader');
+        $feedId = $config->getByPluginName('CseEightselectBasic')['8s_feed_id'];
         $prefix = $feedId . '/' . $feedType . '/' . date('Y') . '/' . date('m') . '/' . date('d');
+        $timestampInMillis = round(microtime(true) * 1000);
+        $filename = sprintf('%s_%s_%d.csv', $feedId, $feedType, $timestampInMillis);
 
+        $region = 'eu-central-1';
         $s3 = new S3Client([
             'version'     => '2006-03-01',
             'region'      => $region,
@@ -32,14 +32,14 @@ class AWSUploader
             ),
         ]);
 
+        $bucket = '__SUBDOMAIN__.8select.io';
         $key = $prefix . '/' . $filename;
-
         try {
             $s3->putObject([
                 'ACL'    => 'bucket-owner-full-control',
                 'Bucket' => $bucket,
                 'Key'    => $key,
-                'Body'   => fopen($storage . $filename, 'r'),
+                'Body'   => fopen($path, 'r'),
             ]);
         } catch (\Exception $exception) {
             Shopware()->PluginLogger()->error('Upload des Export auf AWS S3 fehlgeschlagen.');

--- a/CseEightselectBasic/Components/ArticleExport.php
+++ b/CseEightselectBasic/Components/ArticleExport.php
@@ -9,8 +9,6 @@ use CseEightselectBasic\Components\Export;
 
 class ArticleExport extends Export
 {
-    const STORAGE = 'files/8select/';
-
     const CRON_NAME = '8select_article_export';
 
     const FEED_TYPE = 'product_feed';

--- a/CseEightselectBasic/Components/ForceFullPropertyExport.php
+++ b/CseEightselectBasic/Components/ForceFullPropertyExport.php
@@ -7,8 +7,6 @@ use CseEightselectBasic\Components\RunCronOnce;
 
 class ForceFullPropertyExport extends Export
 {
-    const STORAGE = 'files/8select/';
-
     const FEED_TYPE = 'property_feed';
 
     const CRON_NAME = '8select_force_full_property_export';

--- a/CseEightselectBasic/Components/PropertyExport.php
+++ b/CseEightselectBasic/Components/PropertyExport.php
@@ -7,8 +7,6 @@ use CseEightselectBasic\Components\RunCronOnce;
 
 class PropertyExport extends Export
 {
-    const STORAGE = 'files/8select/';
-
     const FEED_TYPE = 'property_feed';
 
     const CRON_NAME = '8select_property_export';

--- a/CseEightselectBasic/Components/RunCronOnce.php
+++ b/CseEightselectBasic/Components/RunCronOnce.php
@@ -9,7 +9,7 @@ class RunCronOnce
         if (self::isScheduled($cronName) || self::isRunning($cronName)) {
             $message = sprintf('%s nicht eingereiht, ist bereits in der Warteschleife.', $cronName);
             if (getenv('ES_DEBUG')) {
-                echo $message . PHP_EOL;
+                echo $message . \PHP_EOL;
             }
             return;
         }

--- a/CseEightselectBasic/CseEightselectBasic.php
+++ b/CseEightselectBasic/CseEightselectBasic.php
@@ -218,7 +218,6 @@ class CseEightselectBasic extends Plugin
         $this->addPropertyOnceCron();
         $this->installWidgets();
         $this->createDatabase($context);
-        $this->createExportDir();
         $this->createAttributes();
 
         $this->sendLog('install');
@@ -276,7 +275,6 @@ class CseEightselectBasic extends Plugin
     private function update_1_0_1()
     {
         $this->deleteExportDir();
-        $this->createExportDir();
     }
 
     private function update_1_5_0()
@@ -310,7 +308,6 @@ class CseEightselectBasic extends Plugin
     private function update_1_6_4()
     {
         $this->deleteExportDir();
-        $this->createExportDir();
     }
 
     private function update_1_8_0()
@@ -1017,16 +1014,10 @@ class CseEightselectBasic extends Plugin
         $cacheManager->clearConfigCache();
     }
 
-    private function createExportDir()
-    {
-        if (!is_dir(ArticleExport::STORAGE)) {
-            mkdir(ArticleExport::STORAGE, 0775, true);
-        }
-    }
 
     private function deleteExportDir()
     {
-        $this->rrmdir(ArticleExport::STORAGE);
+        $this->rrmdir(Shopware()->DocPath('files_8select'));
     }
 
     private function rrmdir($dir)


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/CSE-1617

**Summary**

* in order to avoid file access problems we let PHP create a tempfile in a location it has writeaccess
* add `files/8select/` dir as fallback within shopware installation directory
* the alternative was to use stream but that got very complicated, because we would have to change the feed processing too (reacting to s3 putobject event, s3 bucket access policy)

<!--
You can assign a team-member to review the PR.
If you are confident that no critical system breaks you can merge without a review.
-->
**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [ ] Unit tests for new / changed logic exist OR no logic changes are passing
