### PR TITLE
CSE-1726 add commented smarty blocks to emotion ExtJS

### DIFF
--- a/CseEightselectBasic/Resources/views/emotion_components/backend/psp_psv.js
+++ b/CseEightselectBasic/Resources/views/emotion_components/backend/psp_psv.js
@@ -1,6 +1,8 @@
+//{block name="emotion_components/backend/psp_psv"}
 Ext.define('Shopware.apps.Emotion.view.components.PspPsv', {
 
     extend: 'Shopware.apps.Emotion.view.components.Base',
 
     alias: 'widget.emotion-8select-psppsv-element'
 });
+//{/block}

--- a/CseEightselectBasic/Resources/views/emotion_components/backend/psp_tlv.js
+++ b/CseEightselectBasic/Resources/views/emotion_components/backend/psp_tlv.js
@@ -1,6 +1,8 @@
+//{block name="emotion_components/backend/psp_tlv"}
 Ext.define('Shopware.apps.Emotion.view.components.PspTlv', {
 
     extend: 'Shopware.apps.Emotion.view.components.Base',
 
     alias: 'widget.emotion-8select-psptlv-element'
 });
+//{/block}

--- a/CseEightselectBasic/Resources/views/emotion_components/backend/sys_psv.js
+++ b/CseEightselectBasic/Resources/views/emotion_components/backend/sys_psv.js
@@ -1,3 +1,4 @@
+//{block name="emotion_components/backend/sys_psv"}
 Ext.define('Shopware.apps.Emotion.view.components.SysPsv', {
 
     extend: 'Shopware.apps.Emotion.view.components.Base',
@@ -82,3 +83,4 @@ Ext.define('Shopware.apps.Emotion.view.components.SysPsv', {
     }
 
 });
+//{/block}


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/CSE-1726

**Summary**

this seems to be necessary sometimes

we just do like the docs say:
https://developers.shopware.com/developers-guide/custom-shopping-world-elements/#advanced:-adding-a-custom-emotion-component-in-extjs

<!--
You can assign a team-member to review the PR.
If you are confident that no critical system breaks you can merge without a review.
-->
**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [ ] Unit tests for new / changed logic exist OR no logic changes are passing
