### PR TITLE
CSE-1732 add template dir via extra subscriber class

### DIFF
--- a/CseEightselectBasic/CseEightselectBasic.php
+++ b/CseEightselectBasic/CseEightselectBasic.php
@@ -62,7 +62,6 @@ class CseEightselectBasic extends Plugin
     public static function getSubscribedEvents()
     {
         return [
-            'Enlight_Controller_Action_PreDispatch' => 'onPreDispatch',
             'Theme_Compiler_Collect_Plugin_Javascript' => 'addJsFiles',
             'Enlight_Controller_Dispatcher_ControllerPath_Frontend_CseEightselectBasic' => 'onGetFrontendCseEightselectBasicController',
             'Enlight_Controller_Dispatcher_ControllerPath_Backend_CseEightselectBasic' => 'onGetBackendCseEightselectBasicController',
@@ -92,11 +91,6 @@ class CseEightselectBasic extends Plugin
         }
 
         return $this->pluginConfigService;
-    }
-
-    public function onPreDispatch()
-    {
-        Shopware()->Template()->addTemplateDir($this->getPath() . '/Resources/views/');
     }
 
     /**

--- a/CseEightselectBasic/Resources/services.xml
+++ b/CseEightselectBasic/Resources/services.xml
@@ -3,6 +3,12 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
+        <service id="cse_eightselect_basic.subscriber.template_registration" class="CseEightselectBasic\Subscriber\TemplateRegistration">
+            <argument>%cse_eightselect_basic.plugin_dir%</argument>
+            <argument type="service" id="template"/>
+            <tag name="shopware.event_subscriber"/>
+        </service>
+
         <service id="cse_eightselect_basic.article_export" class="CseEightselectBasic\Components\ArticleExport"> </service>
         <service id="cse_eightselect_basic.property_export" class="CseEightselectBasic\Components\PropertyExport"> </service>
         <service id="cse_eightselect_basic.force_full_property_export" class="CseEightselectBasic\Components\ForceFullPropertyExport"> </service>

--- a/CseEightselectBasic/Subscriber/TemplateRegistration.php
+++ b/CseEightselectBasic/Subscriber/TemplateRegistration.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace CseEightselectBasic\Subscriber;
+
+use Enlight\Event\SubscriberInterface;
+
+class TemplateRegistration implements SubscriberInterface
+{
+    /**
+     * @var string
+     */
+    private $pluginDirectory;
+
+    /**
+     * @var \Enlight_Template_Manager
+     */
+    private $templateManager;
+
+    /**
+     * @param $pluginDirectory
+     * @param \Enlight_Template_Manager $templateManager
+     */
+    public function __construct($pluginDirectory, \Enlight_Template_Manager $templateManager)
+    {
+        $this->pluginDirectory = $pluginDirectory;
+        $this->templateManager = $templateManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            'Enlight_Controller_Action_PreDispatch' => 'onPreDispatch',
+        ];
+    }
+
+    public function onPreDispatch()
+    {
+        $this->templateManager->addTemplateDir($this->pluginDirectory . '/Resources/views/');
+    }
+}


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/CSE-1732

**Summary**

* use extra subscriber class to register smarty template dir - this is exactly what Shopware does in it's [example plugin](https://developers.shopware.com/developers-guide/example-plugin/#register-template-first)

<img width="1222" alt="bildschirmfoto 2018-12-27 um 22 40 37" src="https://user-images.githubusercontent.com/1506973/50495283-7afecf80-0a28-11e9-8e98-829406350030.png">


<!--
You can assign a team-member to review the PR.
If you are confident that no critical system breaks you can merge without a review.
-->
**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [ ] Unit tests for new / changed logic exist OR no logic changes are passing
