### PR TITLE
CSE-836 php unit tests

### DIFF
--- a/CseEightselectBasic/phpunit.xml.dist
+++ b/CseEightselectBasic/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="./tests/Functional/Bootstrap.php">
-  <testsuite name="CseEightselectBasic Test Suite">
+  <testsuite name="Default">
     <directory>./tests</directory>
   </testsuite>
 

--- a/CseEightselectBasic/phpunit.xml.dist
+++ b/CseEightselectBasic/phpunit.xml.dist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="./tests/Functional/Bootstrap.php">
+  <testsuite name="CseEightselectBasic Test Suite">
+    <directory>./tests</directory>
+  </testsuite>
+
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+      <exclude>
+        <directory suffix=".php">./tests</directory>
+
+        <!-- Bootstrap -->
+        <file>CseEightselectBasic.php</file>
+        <directory>./vendor</directory>
+      </exclude>
+    </whitelist>
+  </filter>
+</phpunit>

--- a/CseEightselectBasic/tests/Functional/Bootstrap.php
+++ b/CseEightselectBasic/tests/Functional/Bootstrap.php
@@ -1,0 +1,39 @@
+<?php
+
+use Shopware\Kernel;
+use Shopware\Models\Shop\Shop;
+
+require __DIR__.'/../../../../../autoload.php';
+
+class CseEightselectBasicTestKernel extends Kernel
+{
+    public static function start()
+    {
+        $kernel = new self(getenv('SHOPWARE_ENV') ?: 'testing', true);
+        $kernel->boot();
+        $container = $kernel->getContainer();
+        $container->get('plugins')->Core()->ErrorHandler()->registerErrorHandler(E_ALL | E_STRICT);
+
+        $repository = $container->get('models')->getRepository(Shop::class);
+        $shop = $repository->getActiveDefault();
+        $shop->registerResources();
+
+        if (!self::assertPlugin('CseEightselectBasic')) {
+            throw new \RuntimeException('Plugin CseEightselectBasic must be installed and activated.');
+        }
+    }
+
+    /**0
+     * @param string $name
+     *
+     * @return bool
+     */
+    private static function assertPlugin($name)
+    {
+        $sql = 'SELECT 1 FROM s_core_plugins WHERE name = ? AND active = 1';
+
+        return (bool) Shopware()->Container()->get('dbal_connection')->fetchColumn($sql, [$name]);
+    }
+}
+
+CseEightselectBasicTestKernel::start();

--- a/CseEightselectBasic/tests/Unit/Services/Export/Helper/ProductPriceTest.php
+++ b/CseEightselectBasic/tests/Unit/Services/Export/Helper/ProductPriceTest.php
@@ -11,6 +11,9 @@ class ProductPriceTest extends \PHPUnit\Framework\TestCase
      */
     private $service;
 
+    /**
+     * @before
+     */
     public function createServiceBefore()
     {
         $this->service = new ProductPrice();

--- a/CseEightselectBasic/tests/Unit/Services/Export/Helper/ProductPriceTest.php
+++ b/CseEightselectBasic/tests/Unit/Services/Export/Helper/ProductPriceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace CseEightselectBasic\tests\Unit\Services\Export\Helper\ProductPrice;
+
+use CseEightselectBasic\Services\Export\Helper\ProductPrice;
+
+class ProductPriceTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var ProductPrice
+     */
+    private $service;
+
+    public function createServiceBefore()
+    {
+        $this->service = new ProductPrice();
+    }
+
+    public function test_it_can_be_created()
+    {
+        $service = new ProductPrice();
+        $this->assertInstanceOf(ProductPrice::class, $service);
+    }
+
+    public function test_it_gets_gross_price()
+    {
+        $article = [
+            'angebots_preis' => 20,
+            'tax' => 19,
+        ];
+        $field = 'angebots_preis';
+
+        $result = $this->service->getGrossPrice($article, $field);
+
+        $this->assertEquals('23.80', $result);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -40,3 +40,16 @@ pandoc --standalone --toc --metadata=title:"8select Curated Shopping Engine - Mo
 ### 3. Debugging
 
 - use https://github.com/FriendsOfShopware/FroshProfiler
+
+### 4. Run Unit Tests
+
+**Note: Running PHP Unit Tests for the 8select CSE plugin requires PHP 7.0 or higher. Please check the PHP version installed on your local web server before installing or using [phpunit](https://phpunit.de/)**
+- for compatibility with PHP v7.1 or higher use phpunit v6.5 or higher
+- for compatibilty with PHP v7.0 use phpunit max. v6.4.44
+- for more information see https://github.com/sebastianbergmann/phpunit/wiki 
+
+**How to run:** 
+- Make sure to have [phpunit](https://phpunit.de/) installed on your local web server
+- Make sure you have the 8select CSE plugin installed in your local shopware environment
+- Open a terminal to your server and move to directory `/shopware/custom/plugins/CseEightSelectBasic`
+- run `phpunit`


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/CSE-836

**Summary**
- added a `phpunit.xml.dist` file to setup executable paths for phpunit
- added `tests` directory to plugin files, containing a `Bootstrap.php` to initialize shopware's kernel
- added a basic test file for `Services/Export/Helper/ProductPrice.php`
  - **Note**: this test is setup to work with PHP 7.0 and PHPunit 6 or higher, see also https://github.com/symfony/symfony/issues/21816#issuecomment-283381522
- added instructions for running phpunit tests to the readme file

**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [x] Unit tests for new / changed logic exist OR no logic changes are passing

**Failing PHP Unit Test:**

![bildschirmfoto 2019-01-07 um 17 30 35](https://user-images.githubusercontent.com/1707307/50779975-16eacf80-12a2-11e9-8d0e-27c8d038b163.png)

**Passing PHP Unit Test:**

![bildschirmfoto 2019-01-07 um 17 23 12](https://user-images.githubusercontent.com/1707307/50779982-1b16ed00-12a2-11e9-9e20-5121f930a0b8.png)
