### PR TITLE
CSE-1835 export raw product-data for dynamic productsets outside fashion scope

### DIFF
--- a/CseEightselectBasic/Controllers/Frontend/CseEightselectBasic.php
+++ b/CseEightselectBasic/Controllers/Frontend/CseEightselectBasic.php
@@ -117,7 +117,7 @@ class Shopware_Controllers_Frontend_CseEightselectBasic extends Enlight_Controll
         }
 
         try {
-            $format = $this->Request()->getParam('format');
+            $format = $this->Request()->getParam('format', 'raw');
             $export = $this->createExport($format);
             if (!$format || !$export) {
                 $this->Response()->setHttpResponseCode(204);
@@ -192,6 +192,9 @@ class Shopware_Controllers_Frontend_CseEightselectBasic extends Enlight_Controll
                 break;
             case 'status':
                 return $this->container->get('cse_eightselect_basic.export.status_export');
+                break;
+            case 'raw':
+                return $this->container->get('cse_eightselect_basic.export.raw_export');
                 break;
         }
     }

--- a/CseEightselectBasic/Controllers/Frontend/CseEightselectBasic.php
+++ b/CseEightselectBasic/Controllers/Frontend/CseEightselectBasic.php
@@ -139,7 +139,7 @@ class Shopware_Controllers_Frontend_CseEightselectBasic extends Enlight_Controll
             );
 
             if ($response === false) {
-                $message = sprintf('json error while exporting');
+                $message = 'json error while exporting';
                 $context = [
                     'error' => [
                         'json_last_error' => json_last_error(),
@@ -156,6 +156,19 @@ class Shopware_Controllers_Frontend_CseEightselectBasic extends Enlight_Controll
 
             return $this->Response()->setBody($response);
         } catch (\Exception $exception) {
+            $logger = $this->container->get('cse_eightselect_basic.setup.helpers.logger');
+            $context = [
+                'exception' => [
+                    'file' => $exception->getFile(),
+                    'line' => $exception->getLine(),
+                    'trace' => $exception->getTrace(),
+                ],
+            ];
+            $logger->log('export', [[
+                'message' => 'error while exporting',
+                'context' => $context,
+            ]], true);
+
             $this->Response()->setHttpResponseCode(500);
             $body = $this->httpBodyFromException($exception, 'GENERAL_ERROR');
             $this->Response()->setBody($body);

--- a/CseEightselectBasic/Resources/services.xml
+++ b/CseEightselectBasic/Resources/services.xml
@@ -62,6 +62,11 @@
             <argument type="service" id="dbal_connection"/>
         </service>
 
+        <service id="cse_eightselect_basic.export.raw_export" class="CseEightselectBasic\Services\Export\RawExport">
+            <argument type="service" id="cse_eightselect_basic.dependencies.provider"/>
+            <argument type="service" id="dbal_connection"/>
+        </service>
+
         <service id="cse_eightselect_basic.request.auth" class="CseEightselectBasic\Services\Request\Auth">
             <argument type="service" id="cse_eightselect_basic.plugin_config.plugin_config"/>
         </service>

--- a/CseEightselectBasic/Services/Export/RawExport.php
+++ b/CseEightselectBasic/Services/Export/RawExport.php
@@ -1,0 +1,331 @@
+<?php
+
+namespace CseEightselectBasic\Services\Export;
+
+use CseEightselectBasic\Services\Dependencies\Provider;
+use CseEightselectBasic\Services\Export\ExportInterface;
+use CseEightselectBasic\Services\Export\RawExportMapper;
+use Doctrine\DBAL\Connection;
+
+class RawExport implements ExportInterface
+{
+
+    /**
+     * @var Provider
+     */
+    private $provider;
+
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @param Provider $container
+     * @param Connection $connection
+     */
+    public function __construct(Provider $provider, Connection $connection)
+    {
+        $this->provider = $provider;
+        $this->connection = $connection;
+    }
+
+    /**
+     * @param int $limit
+     * @param int $offset
+     * @param bool $isDeltaExport = true
+     * @return array
+     */
+    public function getProducts($limit, $offset, $isDeltaExport = true)
+    {
+        $articleIds = $this->getArticleIds($limit, $offset);
+
+        $rootData = $this->getRootData($articleIds);
+        $configuratorGroups = $this->getConfiguratorGroups($articleIds);
+        $filterOptions = $this->getFilterOptions($articleIds);
+        $categories = $this->getCategories($articleIds);
+
+        $products = [];
+        foreach ($rootData as $product) {
+            $sku = $product['sku'];
+            $products[] = array_merge(
+                $product,
+                $configuratorGroups[$sku] ? $configuratorGroups[$sku] : [],
+                $filterOptions[$sku] ? $filterOptions[$sku] : [],
+                $categories[$sku] ? $categories[$sku] : []
+            );
+        }
+
+        return $products;
+    }
+
+    private function getArticleIds($limit, $offset)
+    {
+        $sqlTemplate = "
+            SELECT
+                s_articles_details.id
+            FROM
+                s_articles_details
+            INNER JOIN (
+                SELECT
+                    articleID
+                FROM
+                    s_articles_categories_ro
+                WHERE
+                    categoryID = %s
+                GROUP BY
+                    articleID
+            ) categoryConstraint ON categoryConstraint.articleID = s_articles_details.articleID
+            LIMIT %d OFFSET %d;
+        ";
+        $activeShop = $this->provider->getShopWithActiveCSE();
+        $sql = sprintf($sqlTemplate, $activeShop->getCategory()->getId(), $limit, $offset);
+        $articlesIds = $this->connection->fetchAll($sql);
+
+        $mapper = function ($row) {
+            return intval($row['id']);
+        };
+
+        return array_map($mapper, $articlesIds);
+    }
+
+    /**
+     * @param array $articleIds
+     * @return array
+     */
+    private function getRootData($articleIds)
+    {
+        $sql = "SELECT
+                s_articles_details.ordernumber as `sku`,
+                s_articles_details.ordernumber as `s_articles_details.ordernumber`,
+                parentArticle.ordernumber as `parentArticle.ordernumber`,
+                s_articles_details.suppliernumber as `s_articles_details.suppliernumber`,
+                s_articles.name as `s_articles.name`,
+                s_articles_supplier.name as `s_articles_supplier.name`,
+                s_articles_details.additionaltext as `s_articles_details.additionaltext`,
+                s_articles_details.weight as `s_articles_details.weight`,
+                s_articles_details.width as `s_articles_details.width`,
+                s_articles_details.height as `s_articles_details.height`,
+                s_articles_details.length as `s_articles_details.length`,
+                s_articles_details.ean as `s_articles_details.ean`,
+                s_core_units.unit as `s_core_units.unit`,
+                s_articles_details.purchaseunit as `s_articles_details.purchaseunit`,
+                s_articles_details.referenceunit as `s_articles_details.referenceunit`,
+                s_articles_details.packunit as `s_articles_details.packunit`,
+                s_articles_details.releasedate as `s_articles_details.releasedate`,
+                s_articles_details.shippingfree as `s_articles_details.shippingfree`,
+                s_articles_details.shippingtime as `s_articles_details.shippingtime`,
+                s_articles.active as `s_articles.active`,
+                s_articles_details.active as `s_articles_details.active`,
+                s_articles.laststock as `s_articles.laststock`,
+                s_articles_details.instock as `s_articles_details.instock`,
+                CAST(
+                    s_articles_prices.price * (100 + s_core_tax.tax) AS DECIMAL(10,0)
+                )
+                as `s_articles_prices.price`,
+                CAST(
+                    IF(
+                        s_articles_prices.pseudoprice = 0,
+                        s_articles_prices.price,
+                        s_articles_prices.pseudoprice
+                    ) * (100 + s_core_tax.tax) AS DECIMAL(10,0)
+                ) as `s_articles_prices.pseudoprice`,
+                IF (
+                    s_articles.active &&
+                    s_articles_details.active &&
+                    (!s_articles.laststock || s_articles_details.instock > 0),
+                    1,
+                    0
+                ) as `s_articles_details.isInStock`,
+                s_articles.metaTitle as `s_articles.metaTitle`,
+                s_articles.keywords as `s_articles.keywords`
+            FROM
+                s_articles_details
+            INNER JOIN
+                s_articles_details AS parentArticle ON parentArticle.articleID = s_articles_details.articleID AND parentArticle.kind = 1
+            INNER JOIN
+                s_articles ON s_articles.id = s_articles_details.articleID
+            LEFT JOIN s_articles_prices
+                ON s_articles_prices.articledetailsID = s_articles_details.id
+                AND s_articles_prices.from = 1
+                AND s_articles_prices.pricegroup = 'EK'
+            LEFT JOIN s_core_tax
+                ON s_core_tax.id = s_articles.taxID
+            LEFT JOIN
+                s_core_units ON s_core_units.id = s_articles_details.unitID
+            LEFT JOIN
+                s_articles_supplier ON s_articles_supplier.id = s_articles.supplierID
+            WHERE
+                s_articles_details.id IN (?);
+        ";
+
+        $articles = $this->connection->fetchAll(
+            $sql,
+            array($articleIds),
+            array(Connection::PARAM_INT_ARRAY)
+        );
+
+        $mapper = new RawExportMapper();
+
+        return array_map(array($mapper, 'map'), $articles);
+    }
+
+    /**
+     * @param array $articleIds
+     * @return array
+     */
+    private function getConfiguratorGroups($articleIds)
+    {
+        $sql = "SELECT
+                s_articles_details.ordernumber as `sku`,
+                s_article_configurator_groups.id as detailSlugSuffix,
+                s_article_configurator_groups.name as detailLabel,
+                s_article_configurator_options.name as detailValue
+            FROM
+                s_articles_details
+            INNER JOIN
+                s_article_configurator_option_relations on s_article_configurator_option_relations.article_id = s_articles_details.id
+            INNER JOIN
+                s_article_configurator_options on s_article_configurator_options.id = s_article_configurator_option_relations.option_id
+            INNER JOIN
+                s_article_configurator_groups on s_article_configurator_groups.id = s_article_configurator_options.group_id
+            WHERE
+                s_articles_details.id IN (?);
+        ";
+
+        $configuratorGroups = $this->connection->fetchAll(
+            $sql,
+            array($articleIds),
+            array(Connection::PARAM_INT_ARRAY)
+        );
+
+        return $this->mergeBySku($configuratorGroups, 's_article_configurator_groups.id=', true);
+    }
+
+    /**
+     * @param array $articleIds
+     * @return array
+     */
+    private function getFilterOptions($articleIds)
+    {
+        $sql = "SELECT
+                s_articles_details.ordernumber as `sku`,
+                s_filter_options.id as `detailSlugSuffix`,
+                s_filter_options.name as `detailLabel`,
+                s_filter_values.value as `detailValue`
+            FROM
+                s_articles_details
+            INNER JOIN
+                s_filter_articles on s_filter_articles.articleID = s_articles_details.id
+            INNER JOIN
+                s_filter_values on s_filter_values.id = s_filter_articles.valueID
+            INNER JOIN
+                s_filter_options on s_filter_options.id = s_filter_values.optionID
+            WHERE
+                s_articles_details.id IN (?);
+        ";
+
+        $filterOptions = $this->connection->fetchAll(
+            $sql,
+            array($articleIds),
+            array(Connection::PARAM_INT_ARRAY)
+        );
+
+        return $this->mergeBySku($filterOptions, 's_filter_options.id=');
+    }
+
+    /**
+     * @param array $articleIds
+     * @return array
+     */
+    private function getCategories($articleIds)
+    {
+        $sql = "SELECT
+                s_articles_details.ordernumber as `sku`,
+                deepestCategory.id as `detailSlugSuffix`,
+                CONCAT('Kategorie ', deepestCategory.id) as `detailLabel`,
+                s_categories.description as `detailValue`
+            FROM
+                s_articles_details
+            INNER JOIN
+                s_articles_categories_ro on s_articles_categories_ro.articleID = s_articles_details.articleID
+            INNER JOIN
+                s_categories on s_categories.id = s_articles_categories_ro.categoryID
+            INNER JOIN
+                s_categories as deepestCategory on deepestCategory.id = s_articles_categories_ro.parentCategoryID
+            WHERE
+                s_articles_details.id IN (?);
+        ";
+
+        $categories = $this->connection->fetchAll(
+            $sql,
+            array($articleIds),
+            array(Connection::PARAM_INT_ARRAY)
+        );
+
+        return $this->mergeBySku($categories, 's_categories.id=');
+    }
+
+    private function mergeBySku($details, $detailSlugPrefix, $isVariantDetail = false)
+    {
+        $detailsPerArticle = [];
+        foreach ($details as $detail) {
+            $detailsOfArticle = [];
+            if (array_key_exists($detail['sku'], $detailsPerArticle)) {
+                $detailsOfArticle = $detailsPerArticle[$detail['sku']];
+            }
+
+            $detailOfArticle = [
+                'label' => $detail['detailLabel'],
+            ];
+            if ($isVariantDetail) {
+                $detailOfArticle['isVariantDetail'] = true;
+            }
+            $detailSlug = $detailSlugPrefix . $detail['detailSlugSuffix'];
+            if (array_key_exists($detailSlug, $detailsOfArticle)) {
+                $detailOfArticle = $detailsOfArticle[$detailSlug];
+            }
+
+            if (array_key_exists('value', $detailOfArticle) && !is_array($detailOfArticle['value'])) {
+                $detailOfArticle['value'] = [$detailOfArticle['value']];
+            }
+            if (array_key_exists('value', $detailOfArticle) && is_array($detailOfArticle['value'])) {
+                $detailOfArticle['value'][] = $detail['detailValue'];
+            }
+            if (!array_key_exists('value', $detailOfArticle)) {
+                $detailOfArticle['value'] = $detail['detailValue'];
+            }
+
+            $detailsOfArticle[$detailSlug] = $detailOfArticle;
+            $detailsPerArticle[$detail['sku']] = $detailsOfArticle;
+        }
+
+        return $detailsPerArticle;
+    }
+
+    public function getTotal($isDeltaExport = true)
+    {
+        $sqlTemplate = "
+            SELECT
+                COUNT(s_articles_details.id)
+            FROM
+                s_articles_details
+            INNER JOIN (
+                SELECT
+                    articleID
+                FROM
+                    s_articles_categories_ro
+                WHERE
+                    categoryID = %s
+                GROUP BY
+                    articleID
+            ) categoryConstraint ON categoryConstraint.articleID = s_articles_details.articleID;
+        ";
+        $activeShop = $this->provider->getShopWithActiveCSE();
+        $sql = sprintf($sqlTemplate, $activeShop->getCategory()->getId());
+
+        $count = $this->connection->fetchColumn($sql);
+
+        return intval($count);
+    }
+}

--- a/CseEightselectBasic/Services/Export/RawExportMapper.php
+++ b/CseEightselectBasic/Services/Export/RawExportMapper.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace CseEightselectBasic\Services\Export;
+
+class RawExportMapper
+{
+
+    /**
+     * @var array
+     */
+    private $map = [
+        's_articles_details.ordernumber' => 'Artikelnummer',
+        's_articles_details.suppliernumber' => 'Herstellernummer',
+        's_articles_details.additionaltext' => 'Zusätzlicher Text',
+        's_articles_details.weight' => 'Gewicht',
+        's_articles_details.width' => 'Breite',
+        's_articles_details.height' => 'Höhe',
+        's_articles_details.length' => 'Länge',
+        's_articles_details.ean' => 'EAN',
+        's_core_units.unit' => 'Maßeinheit',
+        's_articles_details.purchaseunit' => 'Inhalt',
+        's_articles_details.referenceunit' => 'Grundeinheit',
+        's_articles_details.packunit' => 'Verpackungseinheit',
+        's_articles_details.releasedate' => 'Erscheinungsdatum',
+        's_articles_details.shippingfree' => 'Versandkostenfrei',
+        's_articles_details.shippingtime' => 'Lieferzeit',
+        'parentArticle.ordernumber' => 'Artikelnummer Hauptartikel',
+        's_articles.active' => 'Aktiv für den Hauptartikel',
+        's_articles_details.active' => 'Aktiv für die Variante',
+        's_articles.laststock' => 'Abverkauf',
+        's_articles_details.instock' => 'Lagerbestand',
+        's_articles_prices.price' => 'Brutto-Preis',
+        's_articles_prices.pseudoprice' => 'Pseudo Brutto-Preis',
+        's_articles_details.isInStock' => 'Bestellbar',
+        's_articles.name' => 'Artikel-Bezeichnung',
+        's_articles.metaTitle' => 'Titel',
+        's_articles.keywords' => 'Keywords',
+        's_articles_supplier.name' => 'Hersteller',
+    ];
+
+    /**
+     * @param array $product - ['slug' => 'detailValue']
+     * @return array ['slug' => ['label' => 'detailLabel', 'value' => 'detailValue']]
+     */
+    public function map($product)
+    {
+        $mapped = [];
+        foreach ($product as $slug => $detailValue) {
+            if ($slug === 'articleID') {
+                continue;
+            }
+            if ($slug === 'sku') {
+                $mapped[$slug] = $detailValue;
+                continue;
+            }
+            $mapped[$slug] = [
+                'label' => $this->getLabel($slug),
+                'value' => $detailValue,
+            ];
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * @param $slug string
+     * @return string
+     */
+    private function getLabel($slug)
+    {
+        if (array_key_exists($slug, $this->map)) {
+            return $this->map[$slug];
+        }
+
+        return $slug;
+    }
+}


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/CSE-1835

**Summary**

In order to use dynamic product-sets without the need of attribute-normalisation and outside the fashion scope, we allow to filter products based on their details. Those details are exported with values as is and are give a name that corresponds to the source table in Shopware.

* export product data in new `productDetail` format
* initially we export a basic set of data, this can be extended anytime


<!--
You can assign a team-member to review the PR.
If you are confident that no critical system breaks you can merge without a review.
-->
**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [ ] Unit tests for new / changed logic exist OR no logic changes are passing
