### PR TITLE
CSE-1918 activate description tab in preview mode

### DIFF
--- a/CseEightselectBasic/Resources/views/frontend/detail/index.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/detail/index.tpl
@@ -51,7 +51,7 @@
 
         {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_detail_tabs"}
         {block name="frontend_detail_tabs_cse"}
-            {if (!{config name="CseEightselectBasicPreviewActive"} && !$smarty.get.preview) || ({config name="CseEightselectBasicPreviewActive"}  && $smarty.get.preview)}
+            {if !{config name="CseEightselectBasicPreviewActive"} || {$smarty.get.preview}}
                 <a href="#" class="tab--link" title="Dazu passt" data-tabName="cse" style="display: none;">Dazu passt</a>
             {/if}
         {/block}
@@ -72,8 +72,9 @@
         {/if}
 
         {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_detail_tabs"}
-            {if (!{config name="CseEightselectBasicPreviewActive"} && !$smarty.get.preview) || ({config name="CseEightselectBasicPreviewActive"}  && $smarty.get.preview)}
-                {block name="frontend_detail_tabs_content_cse"}
+            {block name="frontend_detail_tabs_content_cse"}
+                {if !{config name="CseEightselectBasicPreviewActive"} || {$smarty.get.preview}}
+
                         <div class="tab--container -eightselect-widget-sw-tab-container" style="display: none;">
                         {block name="frontend_detail_tabs_content_cse_inner"}
                             {block name="frontend_detail_tabs_content_cse_title"}
@@ -109,8 +110,8 @@
 
                         {/block}
                         </div>
-                {/block}
-            {/if}
+                {/if}
+            {/block}
         {/if}
 
         {if {config name="CseEightselectBasicSysPsvPosition"} == "widget_before"}

--- a/CseEightselectBasic/Resources/views/frontend/detail/index.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/detail/index.tpl
@@ -49,7 +49,7 @@
             {$smarty.block.parent}
         {/if}
 
-        {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_detail_tabs" && {config name="CseEightselectBasicSysPsvBlock"} != "none"}
+        {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_detail_tabs"}
         {block name="frontend_detail_tabs_cse"}
             {if (!{config name="CseEightselectBasicPreviewActive"} && !$smarty.get.preview) || ({config name="CseEightselectBasicPreviewActive"}  && $smarty.get.preview)}
                 <a href="#" class="tab--link" title="Dazu passt" data-tabName="cse" style="display: none;">Dazu passt</a>

--- a/CseEightselectBasic/Resources/views/frontend/detail/index.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/detail/index.tpl
@@ -51,7 +51,9 @@
 
         {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_detail_tabs" && {config name="CseEightselectBasicSysPsvBlock"} != "none"}
         {block name="frontend_detail_tabs_cse"}
+            {if (!{config name="CseEightselectBasicPreviewActive"} && !$smarty.get.preview) || ({config name="CseEightselectBasicPreviewActive"}  && $smarty.get.preview)}
                 <a href="#" class="tab--link" title="Dazu passt" data-tabName="cse" style="display: none;">Dazu passt</a>
+            {/if}
         {/block}
         {/if}
 
@@ -70,43 +72,45 @@
         {/if}
 
         {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_detail_tabs"}
-            {block name="frontend_detail_tabs_content_cse"}
-                    <div class="tab--container -eightselect-widget-sw-tab-container" style="display: none;">
-                    {block name="frontend_detail_tabs_content_cse_inner"}
-                        {block name="frontend_detail_tabs_content_cse_title"}
-                                <div class="tab--header">
-                                {block name="frontend_detail_tabs_content_cse_title_inner"}
-                                        <a href="#" class="tab--title" title="Dazu passt">Dazu passt</a>
-                                {/block}
-                                </div>
-                        {/block}
-
-                        {block name="frontend_detail_tabs_cse_preview"}
-                                <div class="tab--preview">
-                                    Dazu passt
-                                </div>
-                        {/block}
-
-                        {block name="frontend_detail_tabs_content_cse_description"}
-                                <div class="tab--content">
-                                {* Offcanvas buttons *}
-                                {block name='frontend_detail_cse_buttons_offcanvas'}
-                                        <div class="buttons--off-canvas">
-                                    {block name='frontend_detail_cse_buttons_offcanvas_inner'}
-                                            <a href="#" title="{"{s name="OffcanvasCloseMenu" namespace="frontend/detail/description"}{/s}"|escape}" class="close--off-canvas">
-                                        <i class="icon--arrow-left"></i>
-                                        {s name="OffcanvasCloseMenu" namespace="frontend/detail/description"}{/s}
-                                        </a>
+            {if (!{config name="CseEightselectBasicPreviewActive"} && !$smarty.get.preview) || ({config name="CseEightselectBasicPreviewActive"}  && $smarty.get.preview)}
+                {block name="frontend_detail_tabs_content_cse"}
+                        <div class="tab--container -eightselect-widget-sw-tab-container" style="display: none;">
+                        {block name="frontend_detail_tabs_content_cse_inner"}
+                            {block name="frontend_detail_tabs_content_cse_title"}
+                                    <div class="tab--header">
+                                    {block name="frontend_detail_tabs_content_cse_title_inner"}
+                                            <a href="#" class="tab--title" title="Dazu passt">Dazu passt</a>
                                     {/block}
                                     </div>
-                                {/block}
-                                {include file="frontend/detail/custom/cse.tpl"}
-                                </div>
-                        {/block}
+                            {/block}
 
-                    {/block}
-                    </div>
-            {/block}
+                            {block name="frontend_detail_tabs_cse_preview"}
+                                    <div class="tab--preview">
+                                        Dazu passt
+                                    </div>
+                            {/block}
+
+                            {block name="frontend_detail_tabs_content_cse_description"}
+                                    <div class="tab--content">
+                                    {* Offcanvas buttons *}
+                                    {block name='frontend_detail_cse_buttons_offcanvas'}
+                                            <div class="buttons--off-canvas">
+                                        {block name='frontend_detail_cse_buttons_offcanvas_inner'}
+                                                <a href="#" title="{"{s name="OffcanvasCloseMenu" namespace="frontend/detail/description"}{/s}"|escape}" class="close--off-canvas">
+                                            <i class="icon--arrow-left"></i>
+                                            {s name="OffcanvasCloseMenu" namespace="frontend/detail/description"}{/s}
+                                            </a>
+                                        {/block}
+                                        </div>
+                                    {/block}
+                                    {include file="frontend/detail/custom/cse.tpl"}
+                                    </div>
+                            {/block}
+
+                        {/block}
+                        </div>
+                {/block}
+            {/if}
         {/if}
 
         {if {config name="CseEightselectBasicSysPsvPosition"} == "widget_before"}

--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -22,6 +22,8 @@
             if (typeof _eightselect_config === "undefined") {
                 var _eightselect_config = {};
             }
+
+            {if !{config name="CseEightselectBasicPreviewActive"} || ({config name="CseEightselectBasicPreviewActive"} && {$smarty.get.preview})}
             _eightselect_config.sys = _eightselect_config.sys || {};
             _eightselect_config.sys.callback = function (error) {
                 if (error) {
@@ -30,6 +32,7 @@
                     _eightselect_shop_plugin.showSys();
                 }
             }
+            {/if}
 
             _eightselect_config['sys-acc'] = _eightselect_config['sys-acc'] || {};
             _eightselect_config['sys-acc'].callback = function (error) {
@@ -73,13 +76,6 @@
                 var _eightselect_shop_plugin = {};
             }
 
-            _eightselect_shop_plugin.showSys = function () {
-                return;
-            };
-            _eightselect_shop_plugin.hideSys = function () {
-                return;
-            };
-
             _eightselect_shop_plugin.addToCart = function (sku, quantity, Promise) {
                 try {
                     var eightselectCartForm = document.querySelector('#eightselect_cart_trigger_form');
@@ -105,65 +101,61 @@
         </script>
 
         {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_detail_tabs"}
-            {* Activate description tab - SYS tab will be activated when CSE finds a set *}
-            <script type="text/javascript">
-                _eightselect_shop_plugin.hideSys = function () {
-                    var tabs = document.querySelectorAll('.tab-menu--product .tab--navigation .tab--link');
+            {if !{config name="CseEightselectBasicPreviewActive"} || ({config name="CseEightselectBasicPreviewActive"} && {$smarty.get.preview})}
+                {* Activate description tab - SYS tab will be activated when CSE finds a set *}
+                <script type="text/javascript">
+                    _eightselect_shop_plugin.hideSys = function () {
+                        var tabs = document.querySelectorAll('.tab-menu--product .tab--navigation .tab--link');
 
-                    {if {config name="CseEightselectBasicSysPsvPosition"} == "widget_before"}
-                        var tabToActivate = tabs && tabs[1];
-                    {/if}
-
-                    {if {config name="CseEightselectBasicSysPsvPosition"} == "widget_after"}
                         var tabToActivate = tabs && tabs[0];
-                    {/if}
+                
+                        if (tabToActivate) {
+                            tabToActivate.click();
+                        }
+                        var cseTab = document.querySelector('a[data-tabname=cse]');
+                        var cseContainer = document.querySelector('div.-eightselect-widget-sw-tab-container');
 
-                    if (tabToActivate) {
-                        tabToActivate.click();
+                        if (cseTab && cseTab.style.display !== 'none') {
+                            cseTab.style.display = 'none';
+                        }
+                        if (cseContainer && cseContainer.style.display !== 'none') {
+                            cseContainer.style.display = 'none';
+                        }
+                    };
+
+                    _eightselect_shop_plugin.showSys = function () {
+                        if (window.document.readyState === 'loading') {
+                            window.addEventListener('DOMContentLoaded', _eightselect_shop_plugin.showSys);
+                            return;
+                        }
+
+                        var cseTab = document.querySelector('a[data-tabname=cse]');
+                        var cseContainer = document.querySelector('div.-eightselect-widget-sw-tab-container');
+
+                        if (!cseTab || !cseContainer) {
+                            return;
+                        }
+
+                        cseTab.style.display = '';
+                        cseContainer.style.display = '';
+                        cseTab.click();
+                    };
+
+                    var domListener = function () {
+                        window.removeEventListener('DOMContentLoaded', domListener);
+                        _eightselect_shop_plugin.hideSys();
+                    };
+
+                    if (window.document.readyState !== 'loading') {
+                        domListener();
+                    } else {
+                        window.addEventListener('DOMContentLoaded', domListener);
                     }
-                    var cseTab = document.querySelector('a[data-tabname=cse]');
-                    var cseContainer = document.querySelector('div.-eightselect-widget-sw-tab-container');
-
-                    if (cseTab && cseTab.style.display !== 'none') {
-                        cseTab.style.display = 'none';
-                    }
-                    if (cseContainer && cseContainer.style.display !== 'none') {
-                        cseContainer.style.display = 'none';
-                    }
-                };
-
-                _eightselect_shop_plugin.showSys = function () {
-                    if (window.document.readyState === 'loading') {
-                        window.addEventListener('DOMContentLoaded', _eightselect_shop_plugin.showSys);
-                        return;
-                    }
-
-                    var cseTab = document.querySelector('a[data-tabname=cse]');
-                    var cseContainer = document.querySelector('div.-eightselect-widget-sw-tab-container');
-
-                    if (!cseTab || !cseContainer) {
-                        return;
-                    }
-
-                    cseTab.style.display = '';
-                    cseContainer.style.display = '';
-                    cseTab.click();
-                };
-
-                var domListener = function () {
-                    window.removeEventListener('DOMContentLoaded', domListener);
-                    _eightselect_shop_plugin.hideSys();
-                };
-
-                if (window.document.readyState !== 'loading') {
-                    domListener();
-                } else {
-                    window.addEventListener('DOMContentLoaded', domListener);
-                }
-            </script>
+                </script>
+            {/if}
         {/if}
 
-        {if !{config name="8s_preview_mode_enabled"} || ({config name="8s_preview_mode_enabled"} && {$smarty.get.preview})}
+        {if !{config name="CseEightselectBasicPreviewActive"} || ({config name="CseEightselectBasicPreviewActive"} && {$smarty.get.preview})}
             <script>
                 if (typeof _eightselect_shop_plugin === "undefined") {
                     var _eightselect_shop_plugin = {};

--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -23,7 +23,6 @@
                 var _eightselect_config = {};
             }
 
-            {if !{config name="CseEightselectBasicPreviewActive"} || ({config name="CseEightselectBasicPreviewActive"} && {$smarty.get.preview})}
             _eightselect_config.sys = _eightselect_config.sys || {};
             _eightselect_config.sys.callback = function (error) {
                 if (error) {
@@ -32,7 +31,6 @@
                     _eightselect_shop_plugin.showSys();
                 }
             }
-            {/if}
 
             _eightselect_config['sys-acc'] = _eightselect_config['sys-acc'] || {};
             _eightselect_config['sys-acc'].callback = function (error) {
@@ -75,6 +73,13 @@
             if (typeof _eightselect_shop_plugin === "undefined") {
                 var _eightselect_shop_plugin = {};
             }
+
+            _eightselect_shop_plugin.showSys = function () {
+                return;
+            };
+            _eightselect_shop_plugin.hideSys = function () {
+                return;
+            };
 
             _eightselect_shop_plugin.addToCart = function (sku, quantity, Promise) {
                 try {

--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -106,8 +106,12 @@
                 <script type="text/javascript">
                     _eightselect_shop_plugin.hideSys = function () {
                         var tabs = document.querySelectorAll('.tab-menu--product .tab--navigation .tab--link');
-
-                        var tabToActivate = tabs && tabs[0];
+                        var tabToActivate = tabs && Array.prototype.slice
+                            .call(tabs)
+                            .filter(function(tab) { 
+                                    return tab.style.display !== 'none' 
+                                }
+                            )[0];
                 
                         if (tabToActivate) {
                             tabToActivate.click();

--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -113,11 +113,11 @@
                         var tabs = document.querySelectorAll('.tab-menu--product .tab--navigation .tab--link');
                         var tabToActivate = tabs && Array.prototype.slice
                             .call(tabs)
-                            .filter(function(tab) { 
-                                    return tab.style.display !== 'none' 
+                            .filter(function(tab) {
+                                    return tab.style.display !== 'none';
                                 }
                             )[0];
-                
+
                         if (tabToActivate) {
                             tabToActivate.click();
                         }

--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -101,7 +101,7 @@
         </script>
 
         {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_detail_tabs"}
-            {if !{config name="CseEightselectBasicPreviewActive"} || ({config name="CseEightselectBasicPreviewActive"} && {$smarty.get.preview})}
+            {if !{config name="CseEightselectBasicPreviewActive"} || {$smarty.get.preview}}
                 {* Activate description tab - SYS tab will be activated when CSE finds a set *}
                 <script type="text/javascript">
                     _eightselect_shop_plugin.hideSys = function () {
@@ -159,7 +159,7 @@
             {/if}
         {/if}
 
-        {if !{config name="CseEightselectBasicPreviewActive"} || ({config name="CseEightselectBasicPreviewActive"} && {$smarty.get.preview})}
+        {if !{config name="CseEightselectBasicPreviewActive"} || {$smarty.get.preview}}
             <script>
                 if (typeof _eightselect_shop_plugin === "undefined") {
                     var _eightselect_shop_plugin = {};


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/CSE-1918

**Summary**

General:
- updated `8s_preview_mode_enabled` smarty config key to `CseEightselectBasicPreviewActive` in templates

IF widget position "Produkttabs" is active in plugin config:
- always activate first _**visible**_ tab (instead of first tab present in DOM) as long as no valid set is available

IF preview mode is active and preview query string parameter is missing
- exclude cse-tab and cse-tab-content from DOM
- exclude tab related JS logic from DOM 

This prevents:
- invisible tabs (like the cse tab) being activated in tab navigation if no valid set is available
- tab related logic from being executed in preview mode when the corresponding query parameter is missing

**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [ ] Unit tests for new / changed logic exist OR no logic changes are passing
