### PR TITLE
CSE-1878 use normalized price in checkout tracking

### DIFF
--- a/CseEightselectBasic/CseEightselectBasic.php
+++ b/CseEightselectBasic/CseEightselectBasic.php
@@ -184,65 +184,10 @@ class CseEightselectBasic extends Plugin
             if ($isCseWidgetConfigValid === false) {
                 return;
             }
-
-            $this->checkoutTracking($view);
-
         } catch (\Exception $exception) {
             $this->logException('onCheckoutConfirm', $exception);
             $this->getCseLogger()->log('operation', $this->logMessages, $this->hasLogError);
         }
-    }
-
-    /**
-     * @param \Enlight_View $view
-     */
-    private function checkoutTracking(\Enlight_View $view)
-    {
-        /** @var \Shopware\Models\Shop\Currency $currentCurrency */
-        $currentCurrency = Shopware()->Shop()->getCurrency();
-
-        if ($currentCurrency->getCurrency() == 'EUR' && $currentCurrency->getDefault()) {
-            $factor = $currentCurrency->getFactor();
-        } else {
-            $currencies = Shopware()->Shop()->getCurrencies();
-            /** @var \Shopware\Models\Shop\Currency $loopCurrency */
-            foreach ($currencies as $loopCurrency) {
-                if ($loopCurrency->getCurrency() == 'EUR') {
-                    $factor = $loopCurrency->getFactor();
-                }
-            }
-        }
-
-        $sBasket = $view->sBasket;
-        foreach ($sBasket as &$basketItem) {
-            foreach ($basketItem as &$itemProperty) {
-                if ($itemProperty['price'] != null) {
-                    $itemProperty = $this->calculatePrice($itemProperty, $factor);
-                }
-            }
-        }
-        $view->assign('sBasket', $sBasket);
-        $view->assign('checkoutFinish', true);
-    }
-
-    /**
-     * @param $itemProperty
-     * @param $factor
-     * @return array
-     */
-    private function calculatePrice($itemProperty, $factor)
-    {
-        $tempPrice = (strpos($itemProperty['price'], ',') != false) ? str_replace(
-            ',',
-            '.',
-            $itemProperty['price']
-        ) : $itemProperty['price'];
-        if ($itemProperty['currencyFactor'] > 0) {
-            $tempPrice = $tempPrice / $itemProperty['currencyFactor'];
-        }
-        $itemProperty['intprice'] = round($tempPrice * 100 * $factor);
-
-        return $itemProperty;
     }
 
     /**

--- a/CseEightselectBasic/Resources/views/frontend/checkout/finish.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/checkout/finish.tpl
@@ -14,7 +14,7 @@
                             {ldelim}
                                 sku: '{$sBasketItem.ordernumber}',
                                 amount: {$sBasketItem.quantity},
-                                price: {$sBasketItem.intprice}
+                                price: {$sBasketItem.priceNumeric / $sBasketItem.currencyFactor * 100}
                             {rdelim},
                         {/foreach}
                     ]


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/CSE-1878

**Summary**

* currently we use the basket item price for the checkout tracking
* this price is based on the currency the customer has chosen
* we need to use the normalized price that is used during product export

* the change will produce wrong prices in some cases, because the basket item
price only has 2 digit precision

example:

base price: 19.99
current currency factor: 0.5
basket price: 9.99
tracked price: 19.98

<!--
You can assign a team-member to review the PR.
If you are confident that no critical system breaks you can merge without a review.
-->
**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [ ] Unit tests for new / changed logic exist OR no logic changes are passing
