### PR TITLE
CSE-2072 disable upgrade to 3.x

### DIFF
--- a/CseEightselectBasic/CseEightselectBasic.php
+++ b/CseEightselectBasic/CseEightselectBasic.php
@@ -292,6 +292,9 @@ class CseEightselectBasic extends Plugin
             );
 
             switch (true) {
+                case version_compare($context->getCurrentVersion(), '3.0.0', '<'):
+                    throw new \Exception('Upgrade auf Version 3 erst mit Release 3.1.0 möglich. </br></br></br></br>Bitte aktivieren sie die aktuelle Version wieder!');
+                    break;
                 case version_compare($context->getCurrentVersion(), '1.11.0', '<='):
                     $update = new Update_1_11_0(
                         $this->container->get('config'),


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/CSE-2072

**Summary**

Existing customers data has to be migrated - to save time now we do not implement any migration step. Therefor existing customers are not allowed to upgrade to 3.x

<!--
You can assign a team-member to review the PR.
If you are confident that no critical system breaks you can merge without a review.
-->
**Checklist**

- [ ] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [ ] Add feature / bug label
- [ ] Unit tests for new / changed logic exist OR no logic changes are passing
