### PR TITLE
add supplier name to list of attributes

### DIFF
--- a/CseEightselectBasic/Services/Export/Attributes.php
+++ b/CseEightselectBasic/Services/Export/Attributes.php
@@ -56,6 +56,7 @@ class Attributes
             ['name' => 's_articles_details.ean', 'label' => 'EAN'],
             ['name' => 's_core_units.unit', 'label' => 'Maßeinheit'],
             ['name' => 's_categories', 'label' => 'Kategorie'],
+            ['name' => 's_articles_supplier.name', 'label' => 'Hersteller'],
         ];
     }
 


### PR DESCRIPTION
as brand is one of the obligatory fields for the fashion addon this has to be accessible inside the attribute mapping