### PR TITLE
ignore unknown attributes and fallback to slug if label is empty

### DIFF
--- a/CseEightselectBasic/Services/Export/Attributes.php
+++ b/CseEightselectBasic/Services/Export/Attributes.php
@@ -89,7 +89,11 @@ class Attributes
      */
     public function getAttributeConfiguration()
     {
-        $sql = "
+        $attributeColumnsQuery = "SHOW COLUMNS FROM s_articles_attributes;";
+        $attributeColumns = $this->connection->fetchAll($attributeColumnsQuery);
+        $attributeColumnsIndexed = array_column($attributeColumns, 'Field', 'Field');
+
+        $attributesQuery = "
             SELECT
                 s_attribute_configuration.column_name as nameSuffix,
                 s_attribute_configuration.label
@@ -100,7 +104,10 @@ class Attributes
             ";
 
         $attributes = [];
-        foreach ($this->connection->fetchAll($sql) as $attribute) {
+        foreach ($this->connection->fetchAll($attributesQuery) as $attribute) {
+            if (!array_key_exists($attribute['nameSuffix'], $attributeColumnsIndexed)) {
+                continue;
+            }
             $attributes[] = [
                 'name' => 's_articles_attributes.' . $attribute['nameSuffix'],
                 'label' => $attribute['label'],

--- a/CseEightselectBasic/Services/Export/Attributes.php
+++ b/CseEightselectBasic/Services/Export/Attributes.php
@@ -75,9 +75,10 @@ class Attributes
 
         $filterOptions = [];
         foreach ($this->connection->fetchAll($sql) as $filterOption) {
+            $name = 's_filter_options.id=' . $filterOption['nameSuffix'];
             $filterOptions[] = [
-                'name' => 's_filter_options.id=' . $filterOption['nameSuffix'],
-                'label' => $filterOption['label'],
+                'name' => $name,
+                'label' => $this->getNonEmpty($filterOption['label'], $name),
             ];
         }
 
@@ -108,12 +109,23 @@ class Attributes
             if (!array_key_exists($attribute['nameSuffix'], $attributeColumnsIndexed)) {
                 continue;
             }
+            $name = 's_articles_attributes.' . $attribute['nameSuffix'];
             $attributes[] = [
-                'name' => 's_articles_attributes.' . $attribute['nameSuffix'],
-                'label' => $attribute['label'],
+                'name' => $name,
+                'label' => $this->getNonEmpty($attribute['label'], $name),
             ];
         }
 
         return $attributes;
+    }
+
+    /**
+     * @param string $label
+     * @param string $name
+     * @return string
+     */
+    private function getNonEmpty($label, $name)
+    {
+        return strlen($label) === 0 ? $name : $label;
     }
 }

--- a/CseEightselectBasic/Services/Export/RawExport.php
+++ b/CseEightselectBasic/Services/Export/RawExport.php
@@ -459,13 +459,13 @@ class RawExport implements ExportInterface
                 $detailsOfArticle = $detailsPerArticle[$detail['s_articles_details.ordernumber']];
             }
 
+            $detailSlug = $detailSlugPrefix . $detail['detailSlugSuffix'];
             $detailOfArticle = [
-                'label' => $detail['detailLabel'],
+                'label' => $this->getNonEmpty($detail['detailLabel'], $detailSlug),
             ];
             if ($isVariantDetail) {
                 $detailOfArticle['isVariantDetail'] = true;
             }
-            $detailSlug = $detailSlugPrefix . $detail['detailSlugSuffix'];
             if (array_key_exists($detailSlug, $detailsOfArticle)) {
                 $detailOfArticle = $detailsOfArticle[$detailSlug];
             }
@@ -556,5 +556,15 @@ class RawExport implements ExportInterface
         }
 
         return $attributes;
+    }
+
+    /**
+     * @param string $label
+     * @param string $name
+     * @return string
+     */
+    private function getNonEmpty($label, $name)
+    {
+        return strlen($label) === 0 ? $name : $label;
     }
 }


### PR DESCRIPTION
- it may happen, that `s_articles_attributes` is missing a column that is still defined in `s_attribute_configuration` - therefor we only return attributes that exist in `s_articles_attributes``
- `s_filter_options.name` or `s_attribute_configuration.label` may be empty or `NULL` - as we really like to have a label, we use the slug as a fallback