### PR TITLE
CSE-2308 allow dynamic positioning for SYS-PSV

### DIFF
--- a/CseEightselectBasic/Resources/config.xml
+++ b/CseEightselectBasic/Resources/config.xml
@@ -72,11 +72,23 @@
                     <label lang="en">Product tabs</label>
                 </option>
                 <option>
+                    <value>frontend_css_selector</value>
+                    <label lang="de">CSS Selektor</label>
+                    <label lang="en">CSS selector</label>
+                </option>
+                <option>
                     <value>none</value>
                     <label lang="de">Nicht automatisch einfügen</label>
                     <label lang="en">Do not insert automatically</label>
                 </option>
             </store>
+        </element>
+        <element type="text" required="false" scope="locale">
+            <name>CseEightselectBasicSysPsvCssSelector</name>
+            <label lang="de">CSS Selektor für Positionierung:</label>
+            <label lang="en">CSS selector for positioning:</label>
+            <description lang="de">CSS Selektor, an dem das SYS-PSV Widget platziert werden soll. Nur wirksam bei Position "CSS Selektor"!</description>
+            <description lang="en">CSS selector where the SYS-PSV widget should be placed. Only effective at position "CSS Selector"!</description>
         </element>
         <!-- WIDGET PLACEMENT-->
         <element type="select" required="true" scope="locale">

--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -82,10 +82,14 @@
             };
 
             _eightselect_shop_plugin.dynamicallyInjectWidget = function(selector) {
+                if (typeof window._8select === "undefined") {
+                    return
+                }
+
                 var customCseContainer = document.createElement('div');
                 var customCseSnippet = document.createElement('div');
                 var target =  document.querySelector(selector);
-                var targetParent = document.querySelector(selector).parentNode;
+                var targetParent = target.parentNode;
 
                 customCseContainer.setAttribute('class', '-eightselect-widget-container');
                 customCseContainer.setAttribute('style', 'display: none;');

--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -81,6 +81,28 @@
                 return;
             };
 
+            _eightselect_shop_plugin.dynamicallyInjectWidget = function(selector) {
+                var customCseContainer = document.createElement('div');
+                var customCseSnippet = document.createElement('div');
+                var target =  document.querySelector(selector);
+                var targetParent = document.querySelector(selector).parentNode;
+
+                customCseContainer.setAttribute('class', '-eightselect-widget-container');
+                customCseContainer.setAttribute('style', 'display: none;');
+                customCseSnippet.setAttribute('data-sku', '{$sArticle.ordernumber}' );
+                customCseSnippet.setAttribute('data-8select-widget-id', 'sys-psv');
+
+                customCseContainer.appendChild(customCseSnippet)
+
+                {if {config name="CseEightselectBasicSysPsvPosition"} == "widget_before"}
+                    targetParent.insertBefore(customCseContainer, target);
+                {else}
+                    targetParent.insertBefore(customCseContainer, target.nextSibling);
+                {/if}
+
+                window._8select.initCSE();
+            };
+
             _eightselect_shop_plugin.addToCart = function (sku, quantity, Promise) {
                 try {
                     var eightselectCartForm = document.querySelector('#eightselect_cart_trigger_form');
@@ -103,6 +125,16 @@
                     return Promise.reject(error);
                 }
             };
+
+            {if !{config name="CseEightselectBasicPreviewActive"} || {$smarty.get.preview}}
+                {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_css_selector"}
+                var injectWidget = function () {
+                    window.removeEventListener('DOMContentLoaded', injectWidget);
+                    _eightselect_shop_plugin.dynamicallyInjectWidget( '{config name="CseEightselectBasicSysPsvCssSelector"}' );
+                } 
+                window.addEventListener('DOMContentLoaded', injectWidget);
+                {/if}
+            {/if}
         </script>
 
         {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_detail_tabs"}

--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -82,10 +82,6 @@
             };
 
             _eightselect_shop_plugin.dynamicallyInjectWidget = function(selector) {
-                if (typeof window._8select === "undefined") {
-                    return
-                }
-
                 var customCseContainer = document.createElement('div');
                 var customCseSnippet = document.createElement('div');
                 var target =  document.querySelector(selector);
@@ -103,6 +99,10 @@
                 {else}
                     targetParent.insertBefore(customCseContainer, target.nextSibling);
                 {/if}
+
+                if (typeof window._8select === "undefined") {
+                    return
+                }
 
                 window._8select.initCSE();
             };

--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -84,7 +84,12 @@
             _eightselect_shop_plugin.dynamicallyInjectWidget = function(selector) {
                 var customCseContainer = document.createElement('div');
                 var customCseSnippet = document.createElement('div');
-                var target =  document.querySelector(selector);
+                var target = document.querySelector(selector);
+
+                if (!target) {
+                    return console.warn('8select CSE Plugin v__VERSION__: CSS selector "%s" does not exist!', selector);
+                }
+
                 var targetParent = target.parentNode;
 
                 customCseContainer.setAttribute('class', '-eightselect-widget-container');
@@ -100,11 +105,13 @@
                     targetParent.insertBefore(customCseContainer, target.nextSibling);
                 {/if}
 
-                if (typeof window._8select === "undefined") {
-                    return
+                if (typeof _8select !== "undefined" && _8select.initCSE) {
+                    try {
+                        _8select.initCSE();
+                    } catch (error) {
+                        console.error(error);
+                    }
                 }
-
-                window._8select.initCSE();
             };
 
             _eightselect_shop_plugin.addToCart = function (sku, quantity, Promise) {
@@ -129,17 +136,19 @@
                     return Promise.reject(error);
                 }
             };
+        </script>
 
+        {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_css_selector"}
             {if !{config name="CseEightselectBasicPreviewActive"} || {$smarty.get.preview}}
-                {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_css_selector"}
+            <script type="text/javascript">
                 var injectWidget = function () {
                     window.removeEventListener('DOMContentLoaded', injectWidget);
                     _eightselect_shop_plugin.dynamicallyInjectWidget( '{config name="CseEightselectBasicSysPsvCssSelector"}' );
                 } 
                 window.addEventListener('DOMContentLoaded', injectWidget);
-                {/if}
+            </script>
             {/if}
-        </script>
+        {/if}
 
         {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_detail_tabs"}
             {if !{config name="CseEightselectBasicPreviewActive"} || {$smarty.get.preview}}

--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -87,7 +87,7 @@
                 var target = document.querySelector(selector);
 
                 if (!target) {
-                    return console.warn('8select CSE Plugin v__VERSION__: CSS selector "%s" does not exist!', selector);
+                    return console.warn('8select CSE Plugin __VERSION__: CSS selector "%s" does not exist!', selector);
                 }
 
                 var targetParent = target.parentNode;


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/CSE-2308

**Summary**
- added new selection "CSS selector" to existing plugin config option "SYS-PSV: Position where the widget will be placed"
- added new plugin config option "CSS selector"
- dynamically inject widget at given CSS selector, while respecting:
  - preview mode
  - block start or end position

**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [x Unit tests for new / changed logic exist OR no logic changes are passing

**Example Setting:**

![screenshot-shopware-5-2-17-php7 dev 8select-2019 07 09-16-12-53](https://user-images.githubusercontent.com/1707307/60895215-872fd900-a264-11e9-880f-a734f12f28af.png)

**Results in:**

![demo-dynamic-positioning](https://user-images.githubusercontent.com/1707307/60895442-f6a5c880-a264-11e9-9888-71141141e3f7.gif)

**If CSS selector does not exist, see JS console:**

![Bildschirmfoto 2019-07-10 um 09 23 28](https://user-images.githubusercontent.com/1707307/60949385-61064980-a2f5-11e9-95cb-ae7f58fabbad.png)
