### PR TITLE
CSE-2308 try-catch missing css selector

### DIFF
--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -84,7 +84,13 @@
             _eightselect_shop_plugin.dynamicallyInjectWidget = function(selector) {
                 var customCseContainer = document.createElement('div');
                 var customCseSnippet = document.createElement('div');
-                var target = document.querySelector(selector);
+                var target 
+
+                try {
+                    target = document.querySelector(selector);
+                } catch (error) {
+                    return console.warn('8select CSE Plugin __VERSION__: Position is "CSS selector" but none was provided.');
+                }
 
                 if (!target) {
                     return console.warn('8select CSE Plugin __VERSION__: CSS selector "%s" does not exist!', selector);


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/CSE-2308

**Summary**

- follow-up for https://github.com/8select/shopware-plugin-sob/pull/115
- try / catch query selection if position is "CSS selector" but none was provided in plugin config 
 
**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [x] Unit tests for new / changed logic exist OR no logic changes are passing


**1. In Plugin Configuration (admin panel):**

![Bildschirmfoto 2019-07-15 um 11 28 24](https://user-images.githubusercontent.com/1707307/61206809-c55d4a80-a6f3-11e9-967d-a8ff56bda379.png)


**2. In JS Console (store front):**

![Bildschirmfoto 2019-07-15 um 11 20 55](https://user-images.githubusercontent.com/1707307/61206813-c8f0d180-a6f3-11e9-964a-0be2cde555de.png)

