### PR TITLE
export article categories that only have one level

### DIFF
--- a/CseEightselectBasic/Services/Export/RawExport.php
+++ b/CseEightselectBasic/Services/Export/RawExport.php
@@ -385,7 +385,7 @@ class RawExport implements ExportInterface
     {
         $sql = "SELECT
                 s_articles_details.ordernumber as `s_articles_details.ordernumber`,
-                CONCAT(s_articles_categories_ro.categoryID, deepestCategory.path) as `path`
+                IFNULL(CONCAT(s_articles_categories_ro.categoryID, deepestCategory.path), deepestCategory.id) as `path`
             FROM
                 s_articles_details
             INNER JOIN


### PR DESCRIPTION
**Summary**

categories with only one level do not have a path
in shopwares article-category structure

therefor those where null before

<!--
You can assign a team-member to review the PR.
If you are confident that no critical system breaks you can merge without a review.
-->
**Checklist**

- [ ] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [ ] Unit tests for new / changed logic exist OR no logic changes are passing
