### PR TITLE
Shopware support ticket - CSE-28886 - avoid clicking CSE tab on mobile on hideSys event

### DIFF
--- a/CseEightselectBasic/CseEightselectBasic.php
+++ b/CseEightselectBasic/CseEightselectBasic.php
@@ -337,7 +337,7 @@ class CseEightselectBasic extends Plugin
                     $this->logMessages[] = 'Update_3_1_0 executed';
             }
 
-            $context->scheduleClearCache([InstallContext::CACHE_TAG_HTTP]);
+            $context->scheduleClearCache(InstallContext::CACHE_LIST_FRONTEND);
 
             $this->logMessages[] = 'Plugin update completed';
             $this->getCseLogger()->log('update', $this->logMessages, $this->hasLogError);

--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -175,11 +175,18 @@
                                 }
                             )[0];
 
-                        if (tabToActivate) {
-                            tabToActivate.click();
+                        if (!tabToActivate || tabToActivate.offsetHeight === 0) {
+                            return;
                         }
+                        tabToActivate.click();
+
+
                         var cseTab = document.querySelector('a[data-tabname=cse]');
                         var cseContainer = document.querySelector('div.-eightselect-widget-sw-tab-container');
+
+                        if (!cseTab || !cseContainer || cseTab.offsetHeight === 0) {
+                            return;
+                        }
 
                         if (cseTab && cseTab.style.display !== 'none') {
                             cseTab.style.display = 'none';


### PR DESCRIPTION
Shopware support ticket CSE-28886

**Summary**

- do not click CSE tab on mobile to avoid unexpected behaviour
- schedule to clear all frontend caches as the default update behaviour
- this PR handles the `hideSys` event that was forgotten in https://github.com/8select/shopware-plugin-sob/pull/123

<!--
You can assign a team-member to review the PR.
If you are confident that no critical system breaks you can merge without a review.
-->
**Checklist**

- [ ] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [ ] Unit tests for new / changed logic exist OR no logic changes are passing