### PR TITLE
CSE-28886 "unhide" tab element before checking if it is visible

### DIFF
--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -205,13 +205,17 @@
                         var cseTab = document.querySelector('a[data-tabname=cse]');
                         var cseContainer = document.querySelector('div.-eightselect-widget-sw-tab-container');
 
-                        if (!cseTab || !cseContainer || cseTab.offsetHeight === 0) {
+                        if (!cseTab || !cseContainer) {
                             return;
                         }
 
                         cseTab.style.display = '';
                         cseContainer.style.display = '';
-                        cseTab.click();
+
+                        // on mobile tabs are not visible and we only want to click on desktop devices
+                        if (cseTab.offsetHeight > 0) {
+                            cseTab.click();
+                        }
                     };
 
                     var domListener = function () {


### PR DESCRIPTION
**Shopware Support Issue**

CSE-28886

**Summary**

follow up on #123 and #124 

before we can actually check via element.offsetHeight if the
element is currently visible we need to try to make it visible
i.e. remove display:'none'

that way the element is visible on desktop client but not on mobile clients
(SW logic)
after setting display:'' we check if the element is actually there,
and it will not be there on mobile devices because it will still be hidden via other responsive stylesheets


<!--
You can assign a team-member to review the PR.
If you are confident that no critical system breaks you can merge without a review.
-->
**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. CSE-42
- [x] Add feature / bug label
- [x] Unit tests for new / changed logic exist OR no logic changes are passing