### PR TITLE
Missing images

### DIFF
--- a/CseEightselectBasic/Controllers/Frontend/CseEightselectBasic.php
+++ b/CseEightselectBasic/Controllers/Frontend/CseEightselectBasic.php
@@ -13,6 +13,7 @@ class Shopware_Controllers_Frontend_CseEightselectBasic extends Enlight_Controll
      */
     public function cartAction()
     {
+        $this->addPluginInfoHeaders();
         $this->Front()->Plugins()->ViewRenderer()->setNoRender();
         $this->Response()->setHeader('Content-Type', 'application/json');
         $this->Response()->setBody(
@@ -23,6 +24,8 @@ class Shopware_Controllers_Frontend_CseEightselectBasic extends Enlight_Controll
 
     public function validateAction()
     {
+        $this->addPluginInfoHeaders();
+
         try {
             $auth = $this->container->get('cse_eightselect_basic.request.auth');
             $auth->auth($this->Request());
@@ -78,6 +81,8 @@ class Shopware_Controllers_Frontend_CseEightselectBasic extends Enlight_Controll
      */
     public function connectAction()
     {
+        $this->addPluginInfoHeaders();
+
         try {
             $auth = $this->container->get('cse_eightselect_basic.request.auth');
             $auth->auth($this->Request());
@@ -125,6 +130,8 @@ class Shopware_Controllers_Frontend_CseEightselectBasic extends Enlight_Controll
      */
     public function attributesAction()
     {
+        $this->addPluginInfoHeaders();
+
         try {
             $auth = $this->container->get('cse_eightselect_basic.request.auth');
             $auth->auth($this->Request());
@@ -173,6 +180,8 @@ class Shopware_Controllers_Frontend_CseEightselectBasic extends Enlight_Controll
      */
     public function variantDimensionsAction()
     {
+        $this->addPluginInfoHeaders();
+
         try {
             $auth = $this->container->get('cse_eightselect_basic.request.auth');
             $auth->auth($this->Request());
@@ -223,6 +232,8 @@ class Shopware_Controllers_Frontend_CseEightselectBasic extends Enlight_Controll
      */
     public function productsAction()
     {
+        $this->addPluginInfoHeaders();
+
         try {
             $auth = $this->container->get('cse_eightselect_basic.request.auth');
             $auth->auth($this->Request());
@@ -387,6 +398,8 @@ class Shopware_Controllers_Frontend_CseEightselectBasic extends Enlight_Controll
      */
     public function migrationAttributeMappingsAction()
     {
+        $this->addPluginInfoHeaders();
+
         try {
             $auth = $this->container->get('cse_eightselect_basic.request.auth');
             $auth->auth($this->Request());
@@ -435,6 +448,8 @@ class Shopware_Controllers_Frontend_CseEightselectBasic extends Enlight_Controll
      */
     public function migrationVariantDimensionsAction()
     {
+        $this->addPluginInfoHeaders();
+
         try {
             $auth = $this->container->get('cse_eightselect_basic.request.auth');
             $auth->auth($this->Request());
@@ -476,5 +491,9 @@ class Shopware_Controllers_Frontend_CseEightselectBasic extends Enlight_Controll
 
             return;
         }
+    }
+
+    private function addPluginInfoHeaders() {
+        $this->Response()->setHeader('8select-com-plugin-version', '__VERSION__');
     }
 }

--- a/bin/lib/build.sh
+++ b/bin/lib/build.sh
@@ -27,6 +27,7 @@ sed -i '' "s@__VERSION__@${VERSION}@g" ${PLUGIN_DIR}/plugin.xml
 sed -i '' "s@__VERSION__@${VERSION}@g" ${PLUGIN_DIR}/Resources/views/frontend/index/header.tpl
 sed -i '' "s@__VERSION__@${VERSION}@g" ${PLUGIN_DIR}/Services/Export/Connector.php
 sed -i '' "s@__VERSION__@${VERSION}@g" ${PLUGIN_DIR}/Setup/Helpers/Logger.php
+sed -i '' "s@__VERSION__@${VERSION}@g" ${PLUGIN_DIR}/Controllers/Frontend/CseEightselectBasic.php
 
 sed -i '' "s@__SHOP_CONNECTOR_URL__@${SHOP_CONNECTOR_URL}@g" ${PLUGIN_DIR}/Services/Export/Connector.php
 sed -i '' "s@__SHOP_CONNECTOR_URL__@${SHOP_CONNECTOR_URL}@g" ${PLUGIN_DIR}/Setup/Helpers/Logger.php


### PR DESCRIPTION
To workaround the situation where image data seems corrupt because `original` is just missing, we use the last entry in the images entry, hoping that this is the biggest thumbnail. 🙈 

Additionally the API will now return the current plugin version in a header field. This way we can see which plugin version the tenant is using directly via the API response. QOL!