### PR TITLE
HX-735 do not disconnect from CSE anymore

### DIFF
--- a/CseEightselectBasic/CseEightselectBasic.php
+++ b/CseEightselectBasic/CseEightselectBasic.php
@@ -277,8 +277,6 @@ class CseEightselectBasic extends Plugin
                 $context->getCurrentVersion()
             );
 
-            $this->disconnectCse();
-
             $context->scheduleClearCache(InstallContext::CACHE_LIST_ALL);
 
             $this->logMessages[] = 'Plugin deactivation completed';
@@ -373,7 +371,6 @@ class CseEightselectBasic extends Plugin
             $this->logMessages[] = 'Plugin components uninstalled';
             $this->removeDatabase();
 
-            $this->disconnectCse();
             $context->scheduleClearCache(InstallContext::CACHE_LIST_ALL);
 
             $this->logMessages[] = 'Plugin deinstallation completed';
@@ -525,21 +522,6 @@ class CseEightselectBasic extends Plugin
             return;
         } catch (\Exception $exception) {
             $this->logException('connecting to cse', $exception);
-        }
-    }
-
-    /**
-     * @throws \Exception
-     */
-    private function disconnectCse()
-    {
-        try {
-            $this->getCseConnector()->disconnect();
-            $this->logMessages[] = 'Disconnected from CSE';
-
-            return;
-        } catch (\Exception $exception) {
-            $this->logException('disconnecting from cse', $exception);
         }
     }
 

--- a/CseEightselectBasic/Services/Export/Connector.php
+++ b/CseEightselectBasic/Services/Export/Connector.php
@@ -100,22 +100,6 @@ class Connector
     }
 
     /**
-     * @throws CseCredentialsMissingException
-     */
-    public function disconnect()
-    {
-        if ($this->canConnect === false) {
-            throw new CseCredentialsMissingException();
-        }
-        $path = sprintf(
-            '/shops/%s/%s',
-            $this->pluginConfig->get('CseEightselectBasicApiId'),
-            $this->pluginConfig->get('CseEightselectBasicFeedId')
-        );
-        $this->guzzleClient->delete($this->getUrl($path));
-    }
-
-    /**
      * @return string
      */
     private function getUrl($path)

--- a/CseEightselectBasic/Services/Export/CseCredentialsMissingException.php
+++ b/CseEightselectBasic/Services/Export/CseCredentialsMissingException.php
@@ -6,6 +6,6 @@ class CseCredentialsMissingException extends \Exception
 {
     public function __construct()
     {
-        parent::__construct('can not connect/disconnect because CSE credentials are not configured');
+        parent::__construct('can not connect because CSE credentials are not configured');
     }
 }


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/HX-735

**Summary**

in some scenarios a shop just disconnected from CSE because there
was a deployment going on and plugins got disabled and enabled again.
to avoid such scenarios we now "lock" a tenant connection to the CSE
and only allow to disconnect the shop manually or via data-reset.

if the plugin is disabled/deinstalled the only thing that will happen
to the shop while it is not disconnected is just a HTTP request
to pull products that will go into nirvana because the plugin is not
installed anymore, i.e. the endpoint the product export is targeting is
not there.

<!--
You can assign a team-member to review the PR.
If you are confident that no critical system breaks you can merge without a review.
-->
**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. HX-42
- [x] Add feature / bug label
- [x] Branch successfully tested on staging