### PR TITLE
HX-740 remove duplicated quotes from doctrine query

### DIFF
--- a/CseEightselectBasic/Services/Export/StatusExport.php
+++ b/CseEightselectBasic/Services/Export/StatusExport.php
@@ -171,7 +171,7 @@ class StatusExport implements ExportInterface
                 LEFT JOIN s_articles_prices as priceGroupPrice
                     ON priceGroupPrice.articledetailsID = s_articles_details.id
                     AND priceGroupPrice.from = 1
-                    AND priceGroupPrice.pricegroup = ":customerGroupKey"
+                    AND priceGroupPrice.pricegroup = :customerGroupKey
                 LEFT JOIN s_articles_prices as defaultPrice
                     ON defaultPrice.articledetailsID = s_articles_details.id
                     AND defaultPrice.from = 1


### PR DESCRIPTION
**Jira Issue**

https://8select.atlassian.net/browse/HX-740

**Summary**

The query syntax was wrong - the double quotes around parameters are wrong.
Doctrine will add quotes when using parameters.

:see_no_evil:


<!--
You can assign a team-member to review the PR.
If you are confident that no critical system breaks you can merge without a review.
-->
**Checklist**

- [x] PR title is prefixed with Jira Issue Id - e.g. HX-42
- [x] Add feature / bug label
- [x] Branch successfully tested on staging