### PR TITLE
always use plugin config of default shop

### DIFF
--- a/CseEightselectBasic/CseEightselectBasic.php
+++ b/CseEightselectBasic/CseEightselectBasic.php
@@ -129,6 +129,35 @@ class CseEightselectBasic extends Plugin
                 'htmlSysAccContainer',
                 explode('CSE_SYS', $this->getPluginConfigService()->get('CseEightselectBasicSysAccContainer'))
             );
+
+            $args->get('subject')->View()->assign(
+                'CseEightselectBasicApiId',
+                $this->getPluginConfigService()->get('CseEightselectBasicApiId')
+            );
+            $args->get('subject')->View()->assign(
+                'CseEightselectBasicPreviewActive',
+                $this->getPluginConfigService()->get('CseEightselectBasicPreviewActive')
+            );
+            $args->get('subject')->View()->assign(
+                'CseEightselectBasicSysAccActive',
+                $this->getPluginConfigService()->get('CseEightselectBasicSysAccActive')
+            );
+            $args->get('subject')->View()->assign(
+                'CseEightselectBasicSysPsvBlock',
+                $this->getPluginConfigService()->get('CseEightselectBasicSysPsvBlock')
+            );
+            $args->get('subject')->View()->assign(
+                'CseEightselectBasicSysPsvPosition',
+                $this->getPluginConfigService()->get('CseEightselectBasicSysPsvPosition')
+            );
+            $args->get('subject')->View()->assign(
+                'CseEightselectBasicCustomCss',
+                $this->getPluginConfigService()->get('CseEightselectBasicCustomCss')
+            );
+            $args->get('subject')->View()->assign(
+                'CseEightselectBasicSysPsvCssSelector',
+                $this->getPluginConfigService()->get('CseEightselectBasicSysPsvCssSelector')
+            );
         } catch (\Exception $exception) {
             $this->logException('onFrontendPostDispatch', $exception);
             $this->getCseLogger()->log('operation', $this->logMessages, $this->hasLogError);

--- a/CseEightselectBasic/Resources/views/emotion_components/widgets/emotion/components/psp_psv.tpl
+++ b/CseEightselectBasic/Resources/views/emotion_components/widgets/emotion/components/psp_psv.tpl
@@ -1,6 +1,6 @@
 {block name="widgets_emotion_components_psp_psv"}
-    {if ($isCseWidgetConfigValid && !{config name="CseEightselectBasicPreviewActive"})
-        || ($isCseWidgetConfigValid&& {config name="CseEightselectBasicPreviewActive"} && {$smarty.get.preview})}
+    {if ($isCseWidgetConfigValid && !{$CseEightselectBasicPreviewActive})
+        || ($isCseWidgetConfigValid&& {$CseEightselectBasicPreviewActive} && {$smarty.get.preview})}
         <div class="-eightselect-widget-container" style="display: none;">
             <div
                 data-set-id="{$Data.psp_psv_set_id}"

--- a/CseEightselectBasic/Resources/views/emotion_components/widgets/emotion/components/psp_tlv.tpl
+++ b/CseEightselectBasic/Resources/views/emotion_components/widgets/emotion/components/psp_tlv.tpl
@@ -1,9 +1,9 @@
 {block name="widgets_emotion_components_psp_tlv"}
-    {if ($isCseWidgetConfigValid && !{config name="CseEightselectBasicPreviewActive"})
-        || ($isCseWidgetConfigValid && {config name="CseEightselectBasicPreviewActive"} && {$smarty.get.preview})}
+    {if ($isCseWidgetConfigValid && !{$CseEightselectBasicPreviewActive})
+        || ($isCseWidgetConfigValid && {$CseEightselectBasicPreviewActive} && {$smarty.get.preview})}
         <div class="-eightselect-widget-container" style="display: none;">
-            <div 
-                data-tags="{$Data.psp_tlv_tags}" 
+            <div
+                data-tags="{$Data.psp_tlv_tags}"
                 data-8select-widget-id="psp-tlv"
                 {if $Data.psp_tlv_lazyload_factor|count_characters > 0 && $Data.psp_tlv_lazyload_factor >= 0}
                     data-load-distance-factor="{$Data.psp_tlv_lazyload_factor}"

--- a/CseEightselectBasic/Resources/views/emotion_components/widgets/emotion/components/sys_psv.tpl
+++ b/CseEightselectBasic/Resources/views/emotion_components/widgets/emotion/components/sys_psv.tpl
@@ -1,6 +1,6 @@
 {block name="widgets_emotion_components_sys_psv"}
-    {if ($isCseWidgetConfigValid && !{config name="CseEightselectBasicPreviewActive"})
-        || ($isCseWidgetConfigValid && {config name="CseEightselectBasicPreviewActive"} && {$smarty.get.preview})}
+    {if ($isCseWidgetConfigValid && !{$CseEightselectBasicPreviewActive})
+        || ($isCseWidgetConfigValid && {$CseEightselectBasicPreviewActive} && {$smarty.get.preview})}
         <div class="-eightselect-widget-container" style="display: none;">
             <div
                 data-sku="{$Data.sys_psv_ordernumber}"

--- a/CseEightselectBasic/Resources/views/frontend/checkout/ajax_add_article.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/checkout/ajax_add_article.tpl
@@ -3,8 +3,8 @@
 {block name='checkout_ajax_add_actions'}
     {$smarty.block.parent}
 
-    {if ($isCseWidgetConfigValid && {config name="CseEightselectBasicSysAccActive"} && !{config name="CseEightselectBasicPreviewActive"})
-        || ($isCseWidgetConfigValid && {config name="CseEightselectBasicSysAccActive"} && {config name="CseEightselectBasicPreviewActive"} && {$smarty.get.preview})}
+    {if ($isCseWidgetConfigValid && {$CseEightselectBasicSysAccActive} && !{$CseEightselectBasicPreviewActive})
+        || ($isCseWidgetConfigValid && {$CseEightselectBasicSysAccActive} && {$CseEightselectBasicPreviewActive} && {$smarty.get.preview})}
 
         <div class="modal--article block-group -eightselect-widget-container">
             <div class="eightselect-sysacc-html" style="display: none">{include file="string:{$htmlSysAccContainer.0}"}</div>

--- a/CseEightselectBasic/Resources/views/frontend/detail/custom/cse.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/detail/custom/cse.tpl
@@ -1,5 +1,5 @@
-{if ($isCseWidgetConfigValid && !{config name="CseEightselectBasicPreviewActive"})
-    || ($isCseWidgetConfigValid && {config name="CseEightselectBasicPreviewActive"} && {$smarty.get.preview})}
+{if ($isCseWidgetConfigValid && !{$CseEightselectBasicPreviewActive})
+    || ($isCseWidgetConfigValid && {$CseEightselectBasicPreviewActive} && {$smarty.get.preview})}
 <div class="-eightselect-widget-container" style="display: none;">
     {include file="string:{$htmlContainer.0}"}
         <div data-sku="{$sArticle.ordernumber}" data-8select-widget-id="sys-psv"></div>

--- a/CseEightselectBasic/Resources/views/frontend/detail/index.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/detail/index.tpl
@@ -2,11 +2,11 @@
 
 {block name='frontend_detail_index_header'}
     {if $isCseWidgetConfigValid}
-        {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_detail_index_header" && {config name="CseEightselectBasicSysPsvPosition"}=="widget_before"}
+        {if {$CseEightselectBasicSysPsvBlock} == "frontend_detail_index_header" && {$CseEightselectBasicSysPsvPosition}=="widget_before"}
             {include file="frontend/detail/custom/cse.tpl"}
         {/if}
         {$smarty.block.parent}
-        {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_detail_index_header" && {config name="CseEightselectBasicSysPsvPosition"}=="widget_after"}
+        {if {$CseEightselectBasicSysPsvBlock} == "frontend_detail_index_header" && {$CseEightselectBasicSysPsvPosition}=="widget_after"}
             {include file="frontend/detail/custom/cse.tpl"}
         {/if}
     {else}
@@ -16,11 +16,11 @@
 
 {block name="frontend_detail_index_detail"}
     {if $isCseWidgetConfigValid}
-        {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_detail_index_detail" && {config name="CseEightselectBasicSysPsvPosition"}=="widget_before"}
+        {if {$CseEightselectBasicSysPsvBlock} == "frontend_detail_index_detail" && {$CseEightselectBasicSysPsvPosition}=="widget_before"}
             {include file="frontend/detail/custom/cse.tpl"}
         {/if}
         {$smarty.block.parent}
-        {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_detail_index_detail" && {config name="CseEightselectBasicSysPsvPosition"}=="widget_after"}
+        {if {$CseEightselectBasicSysPsvBlock} == "frontend_detail_index_detail" && {$CseEightselectBasicSysPsvPosition}=="widget_after"}
             {include file="frontend/detail/custom/cse.tpl"}
         {/if}
     {else}
@@ -31,11 +31,11 @@
 {* Crossselling tab panel *}
 {block name="frontend_detail_index_tabs_cross_selling"}
     {if $isCseWidgetConfigValid}
-        {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_detail_index_tabs_cross_selling" && {config name="CseEightselectBasicSysPsvPosition"}=="widget_before"}
+        {if {$CseEightselectBasicSysPsvBlock} == "frontend_detail_index_tabs_cross_selling" && {$CseEightselectBasicSysPsvPosition}=="widget_before"}
             {include file="frontend/detail/custom/cse.tpl"}
         {/if}
         {$smarty.block.parent}
-        {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_detail_index_tabs_cross_selling" && {config name="CseEightselectBasicSysPsvPosition"}=="widget_after"}
+        {if {$CseEightselectBasicSysPsvBlock} == "frontend_detail_index_tabs_cross_selling" && {$CseEightselectBasicSysPsvPosition}== "widget_after"}
             {include file="frontend/detail/custom/cse.tpl"}
         {/if}
     {else}
@@ -45,19 +45,19 @@
 
 {block name="frontend_detail_tabs_navigation_inner"}
     {if $isCseWidgetConfigValid}
-        {if {config name="CseEightselectBasicSysPsvPosition"} == "widget_after"}
+        {if {$CseEightselectBasicSysPsvPosition} == "widget_after"}
             {$smarty.block.parent}
         {/if}
 
-        {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_detail_tabs"}
+        {if {$CseEightselectBasicSysPsvBlock} == "frontend_detail_tabs"}
         {block name="frontend_detail_tabs_cse"}
-            {if !{config name="CseEightselectBasicPreviewActive"} || {$smarty.get.preview}}
+            {if !{$CseEightselectBasicPreviewActive} || {$smarty.get.preview}}
                 <a href="#" class="tab--link" title="Dazu passt" data-tabName="cse" style="display: none;">Dazu passt</a>
             {/if}
         {/block}
         {/if}
 
-        {if {config name="CseEightselectBasicSysPsvPosition"} == "widget_before"}
+        {if {$CseEightselectBasicSysPsvPosition} == "widget_before"}
             {$smarty.block.parent}
         {/if}
     {else}
@@ -67,13 +67,13 @@
 
 {block name="frontend_detail_tabs_content_inner"}
     {if $isCseWidgetConfigValid}
-        {if {config name="CseEightselectBasicSysPsvPosition"} == "widget_after"}
+        {if {$CseEightselectBasicSysPsvPosition} == "widget_after"}
             {$smarty.block.parent}
         {/if}
 
-        {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_detail_tabs"}
+        {if {$CseEightselectBasicSysPsvBlock} == "frontend_detail_tabs"}
             {block name="frontend_detail_tabs_content_cse"}
-                {if !{config name="CseEightselectBasicPreviewActive"} || {$smarty.get.preview}}
+                {if !{$CseEightselectBasicPreviewActive} || {$smarty.get.preview}}
 
                         <div class="tab--container -eightselect-widget-sw-tab-container" style="display: none;">
                         {block name="frontend_detail_tabs_content_cse_inner"}
@@ -114,7 +114,7 @@
             {/block}
         {/if}
 
-        {if {config name="CseEightselectBasicSysPsvPosition"} == "widget_before"}
+        {if {$CseEightselectBasicSysPsvPosition} == "widget_before"}
             {$smarty.block.parent}
         {/if}
     {else}

--- a/CseEightselectBasic/Resources/views/frontend/index/header.tpl
+++ b/CseEightselectBasic/Resources/views/frontend/index/header.tpl
@@ -2,9 +2,9 @@
 
 {block name="frontend_index_header_css_screen"}
     {$smarty.block.parent}
-    {if $isCseWidgetConfigValid && {config name="CseEightselectBasicCustomCss"} != ""}
+    {if $isCseWidgetConfigValid && {$CseEightselectBasicCustomCss} != ""}
         <style>
-            {include file='string:{config name="CseEightselectBasicCustomCss"}'}
+            {include file='string:{$CseEightselectBasicCustomCss}'}
         </style>
     {/if}
 {/block}
@@ -58,7 +58,7 @@
                     };
                 }(w);
                 var script = d.createElement(s);
-                script.src = 'https://__SUBDOMAIN__.8select.io/{config name="CseEightselectBasicApiId"}/loader.js';
+                script.src = 'https://__SUBDOMAIN__.8select.io/{$CseEightselectBasicApiId}/loader.js';
 
                 if (!!getUrlParameter('8s_demo')) {
                     script.src = 'https://__SUBDOMAIN__.8select.io/db54750f-80fc-4818-9455-30ca233225dc/loader.js';
@@ -111,7 +111,7 @@
                     ${ htmlContentAfter }
                 `);
 
-                {if {config name="CseEightselectBasicSysPsvPosition"} == "widget_before"}
+                {if {$CseEightselectBasicSysPsvPosition} == "widget_before"}
                     targetParent.insertBefore(customCseContainer, target);
                 {else}
                     targetParent.insertBefore(customCseContainer, target.nextSibling);
@@ -150,20 +150,20 @@
             };
         </script>
 
-        {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_css_selector"}
-            {if !{config name="CseEightselectBasicPreviewActive"} || {$smarty.get.preview}}
+        {if {$CseEightselectBasicSysPsvBlock} == "frontend_css_selector"}
+            {if !{$CseEightselectBasicPreviewActive} || {$smarty.get.preview}}
             <script type="text/javascript">
                 var injectWidget = function () {
                     window.removeEventListener('DOMContentLoaded', injectWidget);
-                    _eightselect_shop_plugin.dynamicallyInjectWidget( '{config name="CseEightselectBasicSysPsvCssSelector"}' );
+                    _eightselect_shop_plugin.dynamicallyInjectWidget( '{$CseEightselectBasicSysPsvCssSelector}' );
                 }
                 window.addEventListener('DOMContentLoaded', injectWidget);
             </script>
             {/if}
         {/if}
 
-        {if {config name="CseEightselectBasicSysPsvBlock"} == "frontend_detail_tabs"}
-            {if !{config name="CseEightselectBasicPreviewActive"} || {$smarty.get.preview}}
+        {if {$CseEightselectBasicSysPsvBlock} == "frontend_detail_tabs"}
+            {if !{$CseEightselectBasicPreviewActive} || {$smarty.get.preview}}
                 {* Activate description tab - SYS tab will be activated when CSE finds a set *}
                 <script type="text/javascript">
                     _eightselect_shop_plugin.hideSys = function () {
@@ -232,7 +232,7 @@
             {/if}
         {/if}
 
-        {if !{config name="CseEightselectBasicPreviewActive"} || {$smarty.get.preview}}
+        {if !{$CseEightselectBasicPreviewActive} || {$smarty.get.preview}}
             <script>
                 if (typeof _eightselect_shop_plugin === "undefined") {
                     var _eightselect_shop_plugin = {};

--- a/CseEightselectBasic/Services/PluginConfig/PluginConfig.php
+++ b/CseEightselectBasic/Services/PluginConfig/PluginConfig.php
@@ -45,7 +45,7 @@ class PluginConfig
     ) {
         $this->container = $container;
         $this->currentShop = $this->getCurrentShop();
-        $this->pluginConfig = $configReader->getByPluginName($pluginName);
+        $this->pluginConfig = $configReader->getByPluginName($pluginName, $this->getDefaultShop());
         $this->configWriter = $configWriter;
     }
 
@@ -103,18 +103,23 @@ class PluginConfig
             return $this->container->get('shop');
         }
 
+        return $this->getDefaultShop();
+    }
+
+    /**
+     * @return DetachedShop
+     */
+    private function getDefaultShop()
+    {
         /** @var ShopRepository $shopRepository */
         $shopRepository = $this->container->get('models')->getRepository(Shop::class);
 
-        return $shopRepository->getActiveDefault();
+        return $shopRepository->getDefault();
     }
 
     public function setDefaults()
     {
-        /** @var ShopRepository $shopRepository */
-        $shopRepository = $this->container->get('models')->getRepository(Shop::class);
-        $defaultShop = $shopRepository->getDefault();
-        $this->configWriter->save('CseEightselectBasicActiveShopId', $defaultShop->getId());
+        $this->configWriter->save('CseEightselectBasicActiveShopId', $this->getDefaultShop()->getId());
     }
 
     /**


### PR DESCRIPTION
- SW default shop is the Shop that is created during SW installation (id = 1)
- most code in shopware with Shop/shopId uses either this default shop as the default or as the default parameter
- when the default shop is not id=1 then the Plugin Config logic seems broken and values are not saved for all shops

To handle this we always use the config of the default shop instead of the current shop.


<!--
You can assign a team-member to review the PR.
If you are confident that no critical system breaks you can merge without a review.
-->
**Checklist**

- [ ] PR title is prefixed with Jira Issue Id - e.g. HX-42
- [ ] Add feature / bug label
- [ ] Branch successfully tested on staging